### PR TITLE
chore: upgrade project to Go 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Build
         run: go build -trimpath -ldflags="-s -w" -v ./...
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Integration Tests
         run: go test -v -count=1 -tags integration ./tests/integration/...
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Build efctl
         run: go build -trimpath -ldflags="-s -w" -o output/efctl main.go
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Install gosec
         run: go install github.com/securego/gosec/v2/cmd/gosec@latest

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ curl -fsSL https://github.com/Scetrov/efctl/releases/latest/download/efctl-darwi
 
 ### From Source
 
-Ensure you have [Go 1.25+](https://go.dev/dl/) installed.
+Ensure you have [Go 1.26+](https://go.dev/dl/) installed.
 
 ```bash
 git clone https://github.com/Scetrov/efctl.git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module efctl
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.10


### PR DESCRIPTION
This PR upgrades the project to Go 1.26, updating go.mod, CI workflows, and documentation. Local builds and tests have been verified.