### PR TITLE
fix: use pinned default refs for env setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     needs: build-and-test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -25,9 +25,9 @@
 | `with-frontend` | Enable builder-scaffold web frontend (Vite) | `false` |
 | `with-graphql` | Enable SQL Indexer and GraphQL API | `false` |
 | `world-contracts-url` | Git URL for world contracts | `https://github.com/evefrontier/world-contracts.git` |
-| `world-contracts-ref` | Branch, tag, or commit for world contracts | `main` |
+| `world-contracts-ref` | Branch, tag, or commit for world contracts | `v0.0.23` |
 | `builder-scaffold-url` | Git URL for builder-scaffold | `https://github.com/evefrontier/builder-scaffold.git` |
-| `builder-scaffold-ref` | Branch, tag, or commit for builder-scaffold | `main` |
+| `builder-scaffold-ref` | Branch, tag, or commit for builder-scaffold | `v0.0.2` |
 | `git-autocrlf` | Enable Git `core.autocrlf` for clones | `false` |
 | `container-engine` | Container engine to use (`docker`, `podman`) | `auto-detect` |
 | `additional-bind-mounts` | List of custom host paths to mount | `[]` |

--- a/efctl.yaml
+++ b/efctl.yaml
@@ -10,14 +10,14 @@ with-graphql: true
 # Git clone URL for the world-contracts repository
 world-contracts-url: "https://github.com/evefrontier/world-contracts.git"
 
-# Ref (branch, tag, or commit) to checkout for world-contracts (default: main)
+# Ref (branch, tag, or commit) to checkout for world-contracts (default: v0.0.23)
 world-contracts-ref: "v0.0.23"
 # world-contracts-branch: "v0.0.23" # Deprecated: use world-contracts-ref
 
 # Git clone URL for the builder-scaffold repository
 builder-scaffold-url: "https://github.com/evefrontier/builder-scaffold.git"
 
-# Ref (branch, tag, or commit) to checkout for builder-scaffold (default: main)
+# Ref (branch, tag, or commit) to checkout for builder-scaffold (default: v0.0.2)
 builder-scaffold-ref: "v0.0.2"
 # builder-scaffold-branch: "v0.0.2" # Deprecated: use builder-scaffold-ref
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,7 +53,7 @@ const DefaultWorldContractsURL = "https://github.com/evefrontier/world-contracts
 // DefaultBuilderScaffoldURL is the default git clone URL for builder-scaffold.
 const DefaultBuilderScaffoldURL = "https://github.com/evefrontier/builder-scaffold.git"
 
-// DefaultBranch is the default git branch to checkout.
+// DefaultBranch is the canonical upstream branch name when branch semantics are needed.
 const DefaultBranch = "main"
 
 // DefaultConfigFile is the default configuration file name.
@@ -275,7 +275,8 @@ func (c *Config) GetBuilderScaffoldURL() string {
 	return DefaultBuilderScaffoldURL
 }
 
-// GetWorldContractsRef returns the configured world-contracts ref, falling back to branch, then default.
+// GetWorldContractsRef returns the configured world-contracts ref, falling back to the
+// deprecated branch field, then the recommended compatible default.
 func (c *Config) GetWorldContractsRef() string {
 	if c != nil {
 		if c.WorldContractsRef != "" {
@@ -285,10 +286,11 @@ func (c *Config) GetWorldContractsRef() string {
 			return c.WorldContractsBranch
 		}
 	}
-	return DefaultBranch
+	return RecommendedWorldContractsRef
 }
 
-// GetBuilderScaffoldRef returns the configured builder-scaffold ref, falling back to branch, then default.
+// GetBuilderScaffoldRef returns the configured builder-scaffold ref, falling back to the
+// deprecated branch field, then the recommended compatible default.
 func (c *Config) GetBuilderScaffoldRef() string {
 	if c != nil {
 		if c.BuilderScaffoldRef != "" {
@@ -298,7 +300,7 @@ func (c *Config) GetBuilderScaffoldRef() string {
 			return c.BuilderScaffoldBranch
 		}
 	}
-	return DefaultBranch
+	return RecommendedBuilderScaffoldRef
 }
 
 // GetGitAutoCRLF returns the configured git-autocrlf option, falling back to false.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -275,7 +275,7 @@ func TestGetBuilderScaffoldURL_Custom(t *testing.T) {
 
 func TestGetWorldContractsRef_Default(t *testing.T) {
 	cfg := &Config{}
-	assert.Equal(t, DefaultBranch, cfg.GetWorldContractsRef())
+	assert.Equal(t, RecommendedWorldContractsRef, cfg.GetWorldContractsRef())
 }
 
 func TestGetWorldContractsRef_Custom(t *testing.T) {
@@ -295,7 +295,7 @@ func TestGetWorldContractsRef_Priority(t *testing.T) {
 
 func TestGetBuilderScaffoldRef_Default(t *testing.T) {
 	cfg := &Config{}
-	assert.Equal(t, DefaultBranch, cfg.GetBuilderScaffoldRef())
+	assert.Equal(t, RecommendedBuilderScaffoldRef, cfg.GetBuilderScaffoldRef())
 }
 
 func TestGetBuilderScaffoldRef_Custom(t *testing.T) {
@@ -317,8 +317,8 @@ func TestGetters_NilConfig(t *testing.T) {
 	var cfg *Config
 	assert.Equal(t, DefaultWorldContractsURL, cfg.GetWorldContractsURL())
 	assert.Equal(t, DefaultBuilderScaffoldURL, cfg.GetBuilderScaffoldURL())
-	assert.Equal(t, DefaultBranch, cfg.GetWorldContractsRef())
-	assert.Equal(t, DefaultBranch, cfg.GetBuilderScaffoldRef())
+	assert.Equal(t, RecommendedWorldContractsRef, cfg.GetWorldContractsRef())
+	assert.Equal(t, RecommendedBuilderScaffoldRef, cfg.GetBuilderScaffoldRef())
 }
 
 func TestFindDefaultConfigPath_FindsInCurrentDirectory(t *testing.T) {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -21,14 +21,14 @@ with-graphql: true
 # Git clone URL for the world-contracts repository
 world-contracts-url: %q
 
-# Ref (branch, tag, or commit) to checkout for world-contracts (default: main)
+# Ref (branch, tag, or commit) to checkout for world-contracts (default: v0.0.23)
 world-contracts-ref: %q
 # world-contracts-branch: %q # Deprecated: use world-contracts-ref
 
 # Git clone URL for the builder-scaffold repository
 builder-scaffold-url: %q
 
-# Ref (branch, tag, or commit) to checkout for builder-scaffold (default: main)
+# Ref (branch, tag, or commit) to checkout for builder-scaffold (default: v0.0.2)
 builder-scaffold-ref: %q
 # builder-scaffold-branch: %q # Deprecated: use builder-scaffold-ref
 

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -539,7 +539,8 @@ func (c *Client) NetworkName() string {
 // BuildImage builds an image from a Dockerfile in the given context directory.
 func (c *Client) BuildImage(ctx context.Context, contextDir string, dockerfileName string, tag string) error {
 	spinner, _ := ui.Spin(fmt.Sprintf("Building image %s...", tag))
-	output, err := c.engineCommandOutput(ctx, "build", "--no-cache", "--rm", "-t", tag, "-f", dockerfileName, contextDir)
+	dockerfilePath := dockerBuildDockerfilePath(contextDir, dockerfileName)
+	output, err := c.engineCommandOutput(ctx, "build", "--no-cache", "--rm", "-t", tag, "-f", dockerfilePath, contextDir)
 	if err != nil {
 		spinner.Fail("Failed to build image")
 		return fmt.Errorf("image build: %w%s", err, trimmedCommandOutputSuffix(output))
@@ -550,6 +551,14 @@ func (c *Client) BuildImage(ctx context.Context, contextDir string, dockerfileNa
 
 	spinner.Success(fmt.Sprintf("Image %s built successfully", tag))
 	return nil
+}
+
+func dockerBuildDockerfilePath(contextDir string, dockerfileName string) string {
+	if dockerfileName == "" || filepath.IsAbs(dockerfileName) || contextDir == "" {
+		return dockerfileName
+	}
+
+	return filepath.Join(contextDir, dockerfileName)
 }
 
 // CreateNetwork creates a bridge network with the given name.

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -157,6 +157,40 @@ func TestPrepareMountConfig_PodmanUsesSharedPropagation(t *testing.T) {
 	}
 }
 
+func TestDockerBuildDockerfilePath(t *testing.T) {
+	tests := []struct {
+		name         string
+		contextDir   string
+		dockerfile   string
+		expectedPath string
+	}{
+		{
+			name:         "relative dockerfile joins context directory",
+			contextDir:   "/tmp/workspace/builder-scaffold/docker",
+			dockerfile:   "Dockerfile",
+			expectedPath: "/tmp/workspace/builder-scaffold/docker/Dockerfile",
+		},
+		{
+			name:         "absolute dockerfile stays absolute",
+			contextDir:   "/tmp/workspace/builder-scaffold/docker",
+			dockerfile:   "/tmp/workspace/builder-scaffold/docker/Dockerfile",
+			expectedPath: "/tmp/workspace/builder-scaffold/docker/Dockerfile",
+		},
+		{
+			name:         "empty context leaves dockerfile unchanged",
+			contextDir:   "",
+			dockerfile:   "Dockerfile",
+			expectedPath: "Dockerfile",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expectedPath, dockerBuildDockerfilePath(test.contextDir, test.dockerfile))
+		})
+	}
+}
+
 func TestPreferredEngineOrder(t *testing.T) {
 	res := &env.CheckResult{HasDocker: true, HasPodman: true}
 

--- a/tests/integration/config_integration_test.go
+++ b/tests/integration/config_integration_test.go
@@ -49,8 +49,8 @@ func TestConfigDefaults(t *testing.T) {
 
 	assert.Equal(t, config.DefaultWorldContractsURL, cfg.GetWorldContractsURL())
 	assert.Equal(t, config.DefaultBuilderScaffoldURL, cfg.GetBuilderScaffoldURL())
-	assert.Equal(t, config.DefaultBranch, cfg.GetWorldContractsRef())
-	assert.Equal(t, config.DefaultBranch, cfg.GetBuilderScaffoldRef())
+	assert.Equal(t, config.RecommendedWorldContractsRef, cfg.GetWorldContractsRef())
+	assert.Equal(t, config.RecommendedBuilderScaffoldRef, cfg.GetBuilderScaffoldRef())
 }
 
 // TestConfigValidation_RejectsInsecure validates that non-HTTPS URLs are rejected.


### PR DESCRIPTION
## Summary
- fix `env up` default clone refs when no `efctl.yaml` is present
- use the pinned compatible refs (`world-contracts v0.0.23`, `builder-scaffold v0.0.2`) instead of falling back to `main`
- align sample config, usage docs, and config tests with the runtime defaults

## Root Cause
The merged branch updated the scaffolded config file to recommended pinned refs, but the runtime getters for an empty config still fell back to `main`.

In E2E, the test workspace does not start with an `efctl.yaml`, so `env up` cloned `world-contracts` and `builder-scaffold` from `main`. Upstream `builder-scaffold/main` no longer matched the expected Docker layout, causing image build to fail with:

`failed to read dockerfile: open Dockerfile: no such file or directory`

## Validation
- `gh` inspection of failing main run: `24469869230`
- `go test ./pkg/config ./tests/integration -tags integration -count=1`
- `go test ./... -count=1`
- local targeted E2E no longer reproduced the Dockerfile failure path; local run was then blocked by an unrelated occupied port `9000`
