### PR TITLE
chore(release): bump version to v0.3.3

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,7 +9,7 @@ import (
 
 // Set via -ldflags at build time
 var (
-	Version   = "v0.3.2"
+	Version   = "v0.3.3"
 	CommitSHA = "unknown"
 	BuildDate = "unknown"
 )


### PR DESCRIPTION
Bumps the default version constant to v0.3.3 so the post-merge release tag points to the final commit on main.

This prepares the repository for the v0.3.3 patch release that includes the security fix from #39 (issue #38).