### PR TITLE
chore(release): bump version to v0.3.4

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,7 +9,7 @@ import (
 
 // Set via -ldflags at build time
 var (
-	Version   = "v0.3.3"
+	Version   = "v0.3.4"
 	CommitSHA = "unknown"
 	BuildDate = "unknown"
 )


### PR DESCRIPTION
Bump version constant to v0.3.4 for patch release.