### PR TITLE
Harden supply-chain workflows and governance docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,7 @@ on:
       - "v*.*.*"
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 jobs:
   build:
@@ -55,6 +53,10 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,35 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "30 6 * * 1"
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  security-events: write
+  id-token: write
+
+jobs:
+  scorecard:
+    name: OpenSSF Scorecard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default ownership for repository changes.
+* @Scetrov
+
+# Extra scrutiny for supply-chain sensitive paths.
+.github/workflows/ @Scetrov
+go.mod @Scetrov
+go.sum @Scetrov
+Dockerfile @Scetrov

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,49 @@
+# efctl Threat Model
+
+## Scope
+
+This document captures the initial security assumptions for `efctl`, its release workflow, and its CI/CD supply chain. It is intended to be reviewed whenever the CLI gains new commands, new deployment targets, or new credentials.
+
+## Assets
+
+- Source code and Git history.
+- GitHub Actions workflows and release artifacts.
+- Release tags, checksums, signatures, SBOMs, and provenance attestations.
+- Maintainer credentials and GitHub tokens.
+- User environments where the compiled CLI is executed.
+
+## Trust boundaries
+
+- Pull requests and issues are untrusted input.
+- GitHub-hosted runners are ephemeral execution environments and should receive only the minimum token permissions needed for each job.
+- Release jobs cross a higher-risk boundary because they can publish artifacts and attestations.
+- Third-party GitHub Actions and Go modules are external supply-chain dependencies and should remain pinned/reviewed.
+
+## Primary threats
+
+- Malicious or compromised dependency introduced through `go.mod` or `go.sum`.
+- Compromised GitHub Action or mutable action reference in CI/CD.
+- Over-broad `GITHUB_TOKEN` permissions in workflows.
+- Unauthorized release or tampered release artifact.
+- Accidental credential exposure in workflow files, logs, configuration, or tests.
+- AI-generated changes that bypass human review or dependency/security checks.
+
+## Current controls
+
+- GitHub Actions are pinned to full-length commit SHAs.
+- Release workflow produces build provenance, SBOM, signatures, and checksums.
+- CodeQL runs on pushes, pull requests, and a schedule.
+- CI uses least-privilege default `contents: read` permissions.
+
+## Recommended repository controls
+
+- Require pull requests for the default branch.
+- Require status checks for CI, CodeQL, dependency review, and Scorecard where appropriate.
+- Require CODEOWNERS review for workflow and dependency changes.
+- Restrict force pushes and branch deletion on protected branches.
+- Enable secret scanning and push protection.
+- Review release tags and publishing permissions periodically.
+
+## Review cadence
+
+Review this threat model at least quarterly and whenever release automation, credential usage, or dependency management materially changes.


### PR DESCRIPTION
## Summary

- Added least-privilege CI workflow permissions.
- Scoped release write permissions to the release job while preserving existing provenance, SBOM, signing, and release steps.
- Added dependency review and OpenSSF Scorecard workflows with pinned action SHAs.
- Added CODEOWNERS and initial threat model documentation.

## Validation

- [x] Analysis proposal generated from `/tmp/efctl-signed-e2e.YoLLTx/proposals/Scetrov_efctl.json`
- [x] `git diff --check`
- [x] Workflow YAML parsed successfully
- [x] Pinned new action SHAs verified against upstream tags
- [x] `go test ./...`
- [x] Commit is signed with GitHub-verified email `git@scetrov.live`
- [x] Token/secret pattern leak check passed

## Manual follow-up required

The PR only changes repository files. A repository or organization administrator still needs to complete these settings tasks:

- [ ] Merge this PR after review and passing checks.
- [ ] Configure branch protection/rulesets for the default branch.
  - Require pull requests before merge.
  - Require at least one approval.
  - Require CODEOWNERS review for sensitive paths after this PR is merged.
  - Restrict force pushes and branch deletion.
- [ ] Add required status checks after the new workflows have run once.
  - Recommended: CI, CodeQL, dependency review, and any required release/provenance checks.
- [ ] Enable or verify secret scanning and push protection in repository or organization settings.
- [ ] Enable or verify Dependabot alerts, security updates, and dependency graph.
- [ ] Confirm CodeQL/code scanning alerts are routed to maintainers.
- [ ] Confirm release publishing and tag creation restrictions match the repository risk.
- [ ] Document AI/agent credential scope, review requirements, and direct-push restrictions.

Suggested verification evidence:

- Ruleset or branch protection screenshot/export.
- List of required status check names.
- Confirmation secret scanning and push protection are enabled.
- Confirmation CODEOWNERS is recognized and requests expected reviews.
- Link to release provenance/SBOM/signature evidence if the repository publishes releases.

No repository settings were changed by this PR automation.
