### PR TITLE
Dynamic host resolution for dashboard endpoint labels

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 
+	"efctl/pkg/config"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -434,4 +436,129 @@ func TestCommandTree_DoctorExists(t *testing.T) {
 		names[c.Name()] = true
 	}
 	assert.True(t, names["doctor"], "doctor command should exist")
+}
+
+// ── resolveDisplayHost ─────────────────────────────────────────────
+
+func TestResolveDisplayHost_Localhost(t *testing.T) {
+	assert.Equal(t, "localhost", resolveDisplayHost("127.0.0.1"))
+}
+
+func TestResolveDisplayHost_CustomIP(t *testing.T) {
+	assert.Equal(t, "172.0.0.1", resolveDisplayHost("172.0.0.1"))
+	assert.Equal(t, "192.168.1.100", resolveDisplayHost("192.168.1.100"))
+	assert.Equal(t, "10.0.0.5", resolveDisplayHost("10.0.0.5"))
+}
+
+func TestResolveDisplayHost_AllInterfaces(t *testing.T) {
+	// 0.0.0.0 should resolve to either the Ethernet IP or fallback to "localhost"
+	got := resolveDisplayHost("0.0.0.0")
+	assert.NotEmpty(t, got)
+	// Should be either an IP or localhost fallback
+	assert.True(t, got == "localhost" || strings.Count(got, ".") == 3,
+		"expected localhost or valid IPv4, got %q", got)
+}
+
+func TestResolveDisplayHost_Empty(t *testing.T) {
+	// An empty host is passed through as-is
+	assert.Equal(t, "", resolveDisplayHost(""))
+}
+
+// ── rpcBaseURL ─────────────────────────────────────────────────────
+
+func TestRpcBaseURL_Localhost(t *testing.T) {
+	assert.Equal(t, "http://localhost", rpcBaseURL("127.0.0.1"))
+}
+
+func TestRpcBaseURL_CustomIP(t *testing.T) {
+	assert.Equal(t, "http://172.0.0.1", rpcBaseURL("172.0.0.1"))
+}
+
+// ── getEthernetIP ──────────────────────────────────────────────────
+
+func TestGetEthernetIP_DoesNotPanic(t *testing.T) {
+	// Call it — must not panic regardless of environment
+	got := getEthernetIP()
+	// If we have network, it should be a valid IPv4 or empty
+	if got != "" {
+		assert.True(t, strings.Count(got, ".") == 3,
+			"expected valid IPv4, got %q", got)
+	}
+}
+
+// ── initialModel host resolution ───────────────────────────────────
+
+func TestInitialModel_HostDefault(t *testing.T) {
+	// Without config.Loaded set, host defaults to 127.0.0.1
+	saved := config.Loaded
+	config.Loaded = nil
+	defer func() { config.Loaded = saved }()
+
+	m := initialModel("docker", t.TempDir())
+	assert.Equal(t, "127.0.0.1", m.host)
+}
+
+func TestInitialModel_HostFromConfig(t *testing.T) {
+	saved := config.Loaded
+	config.Loaded = &config.Config{Host: "0.0.0.0"}
+	defer func() { config.Loaded = saved }()
+
+	m := initialModel("docker", t.TempDir())
+	assert.Equal(t, "0.0.0.0", m.host)
+}
+
+// ── writeEnvConfig URL rendering ───────────────────────────────────
+
+func TestWriteEnvConfig_UrlsWithLocalhostHost(t *testing.T) {
+	m := model{
+		host:      "127.0.0.1",
+		graphqlOn: true,
+		frontendOn: true,
+		width:    120,
+		envVars:  map[string]string{},
+	}
+	var buf bytes.Buffer
+	m.writeEnvConfig(&buf, func(s string) string { return s })
+
+	out := buf.String()
+	assert.Contains(t, out, "http://localhost:9000")
+	assert.Contains(t, out, "http://localhost:9125/graphql")
+	assert.Contains(t, out, "http://localhost:5173")
+}
+
+func TestWriteEnvConfig_UrlsWithCustomHost(t *testing.T) {
+	m := model{
+		host:      "172.0.0.1",
+		graphqlOn: true,
+		frontendOn: true,
+		width:    120,
+		envVars:  map[string]string{},
+	}
+	var buf bytes.Buffer
+	m.writeEnvConfig(&buf, func(s string) string { return s })
+
+	out := buf.String()
+	assert.Contains(t, out, "http://172.0.0.1:9000")
+	assert.Contains(t, out, "http://172.0.0.1:9125/graphql")
+	assert.Contains(t, out, "http://172.0.0.1:5173")
+}
+
+func TestWriteEnvConfig_GqlAndFeOff(t *testing.T) {
+	m := model{
+		host:      "127.0.0.1",
+		graphqlOn: false,
+		frontendOn: false,
+		width:    120,
+		envVars:  map[string]string{},
+	}
+	var buf bytes.Buffer
+	m.writeEnvConfig(&buf, func(s string) string { return s })
+
+	out := buf.String()
+	assert.Contains(t, out, "RPC:")
+	assert.Contains(t, out, "http://localhost:9000")
+	assert.NotContains(t, out, "GraphQL:")
+	assert.NotContains(t, out, "Frontend:")
+	assert.NotContains(t, out, "9125")
+	assert.NotContains(t, out, "5173")
 }

--- a/cmd/env_dash.go
+++ b/cmd/env_dash.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -15,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"efctl/pkg/config"
 	"efctl/pkg/container"
 	"efctl/pkg/dashboard"
 	"efctl/pkg/env"
@@ -266,6 +268,59 @@ func formatCPU(cpu string) string {
 // formatMem delegates to the dashboard package.
 func formatMem(mem string) string {
 	return dashboard.FormatMem(mem)
+}
+
+// resolveDisplayHost returns the display-friendly host for URLs shown in the dashboard.
+// "127.0.0.1" → "localhost", "0.0.0.0" → ethernet IP, anything else → as-is.
+func resolveDisplayHost(host string) string {
+	if host == "127.0.0.1" {
+		return "localhost"
+	}
+	if host == "0.0.0.0" {
+		if ip := getEthernetIP(); ip != "" {
+			return ip
+		}
+		return "localhost" // fallback when no Ethernet IP found
+	}
+	return host
+}
+
+// getEthernetIP returns the first non-loopback IPv4 address of an up interface.
+func getEthernetIP() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			if ipv4 := ip.To4(); ipv4 != nil {
+				return ipv4.String()
+			}
+		}
+	}
+	return ""
+}
+
+// rpcBaseURL returns the base HTTP URL for the RPC endpoint (scheme + host).
+func rpcBaseURL(host string) string {
+	return "http://" + resolveDisplayHost(host)
 }
 
 func fetchChainInfo(client *http.Client) chainStat {
@@ -656,6 +711,7 @@ type model struct {
 	frontendOn     bool         // whether the frontend dApp container is enabled
 	worldEvents    []worldEvent // recent events from the world package
 	restarting     bool         // whether we are in the interactive restart menu
+	host           string       // bind address for container ports (from config, default 127.0.0.1)
 }
 
 func initialModel(engine string, workspace string) model {
@@ -672,6 +728,13 @@ func initialModel(engine string, workspace string) model {
 			feOn = true
 		}
 	}
+
+	// Resolve host from config (defaults to 127.0.0.1)
+	host := "127.0.0.1"
+	if config.Loaded != nil {
+		host = config.Loaded.GetHost()
+	}
+
 	return model{
 		engine:     engine,
 		workspace:  workspace,
@@ -682,6 +745,7 @@ func initialModel(engine string, workspace string) model {
 		adminAddr:  "Checking...",
 		graphqlOn:  gqlOn,
 		frontendOn: feOn,
+		host:       host,
 	}
 }
 
@@ -1324,7 +1388,7 @@ func (m model) writeEnvConfig(b *bytes.Buffer, shorten func(string) string) {
 	}
 	items := []item{
 		{label: " Network:", value: network},
-		{label: "RPC:", value: "http://localhost:9000"},
+		{label: "RPC:", value: "http://" + resolveDisplayHost(m.host) + ":9000"},
 	}
 	if v, ok := m.envVars["TENANT"]; ok {
 		items = append(items, item{label: "Tenant:", value: v})
@@ -1333,10 +1397,10 @@ func (m model) writeEnvConfig(b *bytes.Buffer, shorten func(string) string) {
 		items = append(items, item{label: "World Pkg:", value: shorten(m.worldPkgID)})
 	}
 	if m.isGraphQLEnabled() {
-		items = append(items, item{label: "GraphQL:", value: "http://localhost:9125/graphql"})
+		items = append(items, item{label: "GraphQL:", value: "http://" + resolveDisplayHost(m.host) + ":9125/graphql"})
 	}
 	if m.isFrontendEnabled() {
-		items = append(items, item{label: "Frontend:", value: "http://localhost:5173"})
+		items = append(items, item{label: "Frontend:", value: "http://" + resolveDisplayHost(m.host) + ":5173"})
 	}
 
 	var currentLine strings.Builder

--- a/efctl.yaml
+++ b/efctl.yaml
@@ -28,6 +28,10 @@ git-autocrlf: false
 # If Podman networking fails on WSL, try setting this to "docker".
 container-engine: auto-detect
 
+# Bind address for container port mappings (default: 127.0.0.1).
+# Set to "0.0.0.0" to expose ports on all network interfaces.
+host: "127.0.0.1"
+
 # Additional host directories to bind-mount into the container environment.
 # additional-bind-mounts:
 #   - hostPath: ./my-extension

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	GitAutoCRLF           *bool                 `yaml:"git-autocrlf"`
 	ContainerEngine       string                `yaml:"container-engine"`
 	AdditionalBindMounts  []AdditionalBindMount `yaml:"additional-bind-mounts"`
+	Host                  string                `yaml:"host"`
 
 	// Internal field to track if a config file was actually loaded
 	configFileLoaded bool
@@ -317,6 +318,14 @@ func (c *Config) GetContainerEngine() string {
 		return c.ContainerEngine
 	}
 	return "auto-detect"
+}
+
+// GetHost returns the configured bind address for container ports, defaulting to 127.0.0.1.
+func (c *Config) GetHost() string {
+	if c != nil && c.Host != "" {
+		return c.Host
+	}
+	return "127.0.0.1"
 }
 
 // WasLoaded returns true if a config file was successfully loaded (not just defaulted).

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -141,6 +141,26 @@ func TestValidate_RejectsInvalidAdditionalBindMountIdentifier(t *testing.T) {
 	assert.Contains(t, err.Error(), "identifier contains invalid characters")
 }
 
+func TestGetContainerEngine_Default(t *testing.T) {
+	cfg := &Config{}
+	assert.Equal(t, "auto-detect", cfg.GetContainerEngine())
+}
+
+func TestGetContainerEngine_Custom(t *testing.T) {
+	cfg := &Config{ContainerEngine: "podman"}
+	assert.Equal(t, "podman", cfg.GetContainerEngine())
+}
+
+func TestGetHost_Default(t *testing.T) {
+	cfg := &Config{}
+	assert.Equal(t, "127.0.0.1", cfg.GetHost())
+}
+
+func TestGetHost_Custom(t *testing.T) {
+	cfg := &Config{Host: "0.0.0.0"}
+	assert.Equal(t, "0.0.0.0", cfg.GetHost())
+}
+
 func TestResolveAdditionalBindMounts_UsesConfigDirectory(t *testing.T) {
 	configDir := t.TempDir()
 	mountDir := filepath.Join(configDir, "contracts")
@@ -319,6 +339,7 @@ func TestGetters_NilConfig(t *testing.T) {
 	assert.Equal(t, DefaultBuilderScaffoldURL, cfg.GetBuilderScaffoldURL())
 	assert.Equal(t, RecommendedWorldContractsRef, cfg.GetWorldContractsRef())
 	assert.Equal(t, RecommendedBuilderScaffoldRef, cfg.GetBuilderScaffoldRef())
+	assert.Equal(t, "127.0.0.1", cfg.GetHost())
 }
 
 func TestFindDefaultConfigPath_FindsInCurrentDirectory(t *testing.T) {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -39,6 +39,10 @@ git-autocrlf: false
 # If Podman networking fails on WSL, try setting this to "docker".
 container-engine: auto-detect
 
+# Bind address for container port mappings (default: 127.0.0.1).
+# Set to "0.0.0.0" to expose ports on all network interfaces.
+host: "127.0.0.1"
+
 # Additional host directories to bind-mount into the container environment.
 # additional-bind-mounts:
 #   - hostPath: ./my-extension

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -53,6 +53,7 @@ type ContainerConfig struct {
 	OpenStdin   bool
 	Healthcheck *HealthcheckDef
 	UsernsMode  string // e.g. "keep-id" for Podman
+	Host        string // bind address for port mappings (default: 127.0.0.1)
 }
 
 // ── Interface ──────────────────────────────────────────────────────
@@ -630,7 +631,7 @@ func (c *Client) ensureContainerImage(ctx context.Context, image string) error {
 
 func (c *Client) buildCreateContainerArgs(cfg ContainerConfig) []string {
 	args := []string{"create", "--name", cfg.Name}
-	args = append(args, c.preparePortConfig(cfg.Ports)...)
+	args = append(args, c.preparePortConfig(cfg.Host, cfg.Ports)...)
 	args = append(args, c.prepareMountConfig(cfg.Mounts)...)
 	args = append(args, c.prepareHealthConfig(cfg.Healthcheck)...)
 	args = append(args, c.prepareNetworkConfig(cfg.NetworkName, cfg.Aliases)...)
@@ -683,7 +684,7 @@ func (c *Client) storeHealthTest(cfg ContainerConfig) {
 	c.healthTests[cfg.Name] = cfg.Healthcheck.Test
 }
 
-func (c *Client) preparePortConfig(ports map[int]int) []string {
+func (c *Client) preparePortConfig(host string, ports map[int]int) []string {
 	if len(ports) == 0 {
 		return nil
 	}
@@ -694,7 +695,7 @@ func (c *Client) preparePortConfig(ports map[int]int) []string {
 	sort.Ints(hostPorts)
 	args := make([]string, 0, len(hostPorts)*2)
 	for _, hostPort := range hostPorts {
-		args = append(args, "-p", fmt.Sprintf("127.0.0.1:%d:%d/tcp", hostPort, ports[hostPort]))
+		args = append(args, "-p", fmt.Sprintf("%s:%d:%d/tcp", host, hostPort, ports[hostPort]))
 	}
 	return args
 }

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -51,7 +51,7 @@ func TestNetworkNameForWorkspace_UniquePerPath(t *testing.T) {
 }
 
 func TestSuiDevConfig_Ports(t *testing.T) {
-	cfg := SuiDevConfig("/workspace", "efctl-test", "docker", false, "sui", "pass", "db", nil)
+	cfg := SuiDevConfig("/workspace", "efctl-test", "docker", false, "sui", "pass", "db", nil, "127.0.0.1")
 	if _, ok := cfg.Ports[9000]; !ok {
 		t.Error("Expected port 9000 in SuiDevConfig")
 	}
@@ -59,7 +59,7 @@ func TestSuiDevConfig_Ports(t *testing.T) {
 		t.Error("Port 9125 should not be present without graphql")
 	}
 
-	cfgGql := SuiDevConfig("/workspace", "efctl-test", "docker", true, "sui", "pass", "db", nil)
+	cfgGql := SuiDevConfig("/workspace", "efctl-test", "docker", true, "sui", "pass", "db", nil, "127.0.0.1")
 	if _, ok := cfgGql.Ports[9125]; !ok {
 		t.Error("Expected port 9125 with graphql enabled")
 	}
@@ -71,12 +71,12 @@ func TestSuiDevConfig_Ports(t *testing.T) {
 func TestSuiDevConfig_PodmanUserns(t *testing.T) {
 	// The sui-dev container must use keep-id to avoid host permission
 	// issues with bind mounts in Podman rootless mode.
-	cfg := SuiDevConfig("/workspace", "efctl-test", "podman", false, "sui", "pass", "db", nil)
+	cfg := SuiDevConfig("/workspace", "efctl-test", "podman", false, "sui", "pass", "db", nil, "127.0.0.1")
 	if cfg.UsernsMode != "keep-id" {
 		t.Errorf("Expected UsernsMode 'keep-id' for Podman sui-dev, got %q", cfg.UsernsMode)
 	}
 
-	cfgDocker := SuiDevConfig("/workspace", "efctl-test", "docker", false, "sui", "pass", "db", nil)
+	cfgDocker := SuiDevConfig("/workspace", "efctl-test", "docker", false, "sui", "pass", "db", nil, "127.0.0.1")
 	if cfgDocker.UsernsMode != "" {
 		t.Errorf("Expected empty UsernsMode for Docker, got %q", cfgDocker.UsernsMode)
 	}
@@ -86,7 +86,7 @@ func TestSuiDevConfig_AdditionalBindMounts(t *testing.T) {
 	cfg := SuiDevConfig("/workspace", "efctl-test", "docker", false, "sui", "pass", "db", []AdditionalBindMount{{
 		Source:     "/tmp/contracts",
 		Identifier: "contracts_mount",
-	}})
+	}}, "127.0.0.1")
 
 	require.Len(t, cfg.Mounts, 4)
 	assert.Equal(t, "/tmp/contracts", cfg.Mounts[3].Source)
@@ -95,7 +95,7 @@ func TestSuiDevConfig_AdditionalBindMounts(t *testing.T) {
 }
 
 func TestPostgresConfig_Healthcheck(t *testing.T) {
-	cfg := PostgresConfig("efctl-test", "sui", "pass", "db")
+	cfg := PostgresConfig("efctl-test", "sui", "pass", "db", "127.0.0.1")
 	if cfg.Healthcheck == nil {
 		t.Fatal("Expected healthcheck for postgres")
 	}
@@ -108,12 +108,50 @@ func TestPostgresConfig_Healthcheck(t *testing.T) {
 }
 
 func TestFrontendConfig_WorkingDir(t *testing.T) {
-	cfg := FrontendConfig("/workspace", "efctl-test", "docker")
+	cfg := FrontendConfig("/workspace", "efctl-test", "docker", "127.0.0.1")
 	if cfg.WorkingDir != "/workspace/builder-scaffold/dapps" {
 		t.Errorf("Expected working dir /workspace/builder-scaffold/dapps, got %q", cfg.WorkingDir)
 	}
 	if cfg.Name != ContainerFrontend {
 		t.Errorf("Expected container name %q, got %q", ContainerFrontend, cfg.Name)
+	}
+}
+
+func TestPreparePortConfig_DefaultHost(t *testing.T) {
+	c := &Client{Engine: "docker"}
+	ports := map[int]int{9000: 9000, 5432: 5432}
+	args := c.preparePortConfig("127.0.0.1", ports)
+
+	// Should have 4 elements: -p 127.0.0.1:5432:5432/tcp -p 127.0.0.1:9000:9000/tcp
+	if len(args) != 4 {
+		t.Fatalf("expected 4 port args, got %d: %v", len(args), args)
+	}
+	if args[0] != "-p" || args[1] != "127.0.0.1:5432:5432/tcp" {
+		t.Fatalf("expected first pair to be -p 127.0.0.1:5432:5432/tcp, got %v", args[:2])
+	}
+	if args[2] != "-p" || args[3] != "127.0.0.1:9000:9000/tcp" {
+		t.Fatalf("expected second pair to be -p 127.0.0.1:9000:9000/tcp, got %v", args[2:])
+	}
+}
+
+func TestPreparePortConfig_CustomHost(t *testing.T) {
+	c := &Client{Engine: "docker"}
+	ports := map[int]int{8080: 3000}
+	args := c.preparePortConfig("0.0.0.0", ports)
+
+	if len(args) != 2 {
+		t.Fatalf("expected 2 port args, got %d", len(args))
+	}
+	if args[0] != "-p" || args[1] != "0.0.0.0:8080:3000/tcp" {
+		t.Fatalf("expected -p 0.0.0.0:8080:3000/tcp, got %v", args)
+	}
+}
+
+func TestPreparePortConfig_EmptyPorts(t *testing.T) {
+	c := &Client{Engine: "docker"}
+	args := c.preparePortConfig("127.0.0.1", nil)
+	if args != nil {
+		t.Fatalf("expected nil for empty ports, got %v", args)
 	}
 }
 

--- a/pkg/container/services.go
+++ b/pkg/container/services.go
@@ -14,7 +14,7 @@ type AdditionalBindMount struct {
 }
 
 // SuiDevConfig returns the ContainerConfig for the main Sui development node.
-func SuiDevConfig(workspace, networkName, engine string, withGraphql bool, pgUser, pgPass, pgDB string, additionalMounts []AdditionalBindMount) ContainerConfig {
+func SuiDevConfig(workspace, networkName, engine string, withGraphql bool, pgUser, pgPass, pgDB string, additionalMounts []AdditionalBindMount, host string) ContainerConfig {
 	builderScaffold := filepath.Join(workspace, "builder-scaffold")
 	worldContracts := filepath.Join(workspace, "world-contracts")
 
@@ -54,6 +54,7 @@ func SuiDevConfig(workspace, networkName, engine string, withGraphql bool, pgUse
 		Tty:         true,
 		OpenStdin:   true,
 		UsernsMode:  usernsMode,
+		Host:        host,
 	}
 }
 
@@ -76,7 +77,7 @@ func additionalBindMountDefs(additionalMounts []AdditionalBindMount) []MountDef 
 }
 
 // PostgresConfig returns the ContainerConfig for the PostgreSQL indexer database.
-func PostgresConfig(networkName, user, password, dbName string) ContainerConfig {
+func PostgresConfig(networkName, user, password, dbName, host string) ContainerConfig {
 	return ContainerConfig{
 		Name:        ContainerPostgres,
 		Image:       ImagePostgres,
@@ -92,10 +93,11 @@ func PostgresConfig(networkName, user, password, dbName string) ContainerConfig 
 			Retries:     30,
 			StartPeriod: 10 * time.Second,
 		},
+		Host: host,
 	}
 }
 
-func FrontendConfig(workspace, networkName, engine string) ContainerConfig {
+func FrontendConfig(workspace, networkName, engine, host string) ContainerConfig {
 	usernsMode := ""
 	if engine == "podman" {
 		usernsMode = "keep-id"
@@ -114,5 +116,6 @@ func FrontendConfig(workspace, networkName, engine string) ContainerConfig {
 		WorkingDir:  "/workspace/builder-scaffold/dapps",
 		Cmd:         []string{"sh", "-c", "set -e\nnpx pnpm install\nexec npx pnpm dev --host 0.0.0.0"},
 		UsernsMode:  usernsMode,
+		Host:        host,
 	}
 }

--- a/pkg/setup/start.go
+++ b/pkg/setup/start.go
@@ -105,7 +105,7 @@ func startPostgres(c container.ContainerClient, ctx context.Context, user, pass,
 		return fmt.Errorf("failed to create pgdata volume: %w", err)
 	}
 
-	pgCfg := container.PostgresConfig(networkName, user, pass, db)
+	pgCfg := container.PostgresConfig(networkName, user, pass, db, config.Loaded.GetHost())
 	if err := c.CreateContainer(ctx, pgCfg); err != nil {
 		return fmt.Errorf("failed to create postgres container: %w", err)
 	}
@@ -125,7 +125,7 @@ func startSuiDev(c container.ContainerClient, ctx context.Context, workspace, do
 		return mountErr
 	}
 
-	suiCfg := container.SuiDevConfig(workspace, networkName, c.GetEngine(), withGraphql, pgUser, pgPass, pgDB, additionalMounts)
+	suiCfg := container.SuiDevConfig(workspace, networkName, c.GetEngine(), withGraphql, pgUser, pgPass, pgDB, additionalMounts, config.Loaded.GetHost())
 	if err := c.CreateContainer(ctx, suiCfg); err != nil {
 		return fmt.Errorf("failed to create sui-playground container: %w", err)
 	}
@@ -141,7 +141,7 @@ func startSuiDev(c container.ContainerClient, ctx context.Context, workspace, do
 
 	// Give the container a moment to start, then verify it is still running
 	// before entering the (potentially long) log-wait loop.
-	time.Sleep(10 * time.Second)
+	time.Sleep(30 * time.Second)
 	if !c.ContainerRunning(container.ContainerSuiPlayground) {
 		exitCode, _ := c.ContainerExitCode(container.ContainerSuiPlayground)
 		lastLogs := c.ContainerLogs(container.ContainerSuiPlayground, 30)
@@ -239,7 +239,7 @@ func startFrontend(c container.ContainerClient, ctx context.Context, workspace s
 		return fmt.Errorf("failed to create frontend modules volume: %w", err)
 	}
 
-	feCfg := container.FrontendConfig(workspace, networkName, c.GetEngine())
+	feCfg := container.FrontendConfig(workspace, networkName, c.GetEngine(), config.Loaded.GetHost())
 	if err := c.CreateContainer(ctx, feCfg); err != nil {
 		return fmt.Errorf("failed to create frontend container: %w", err)
 	}


### PR DESCRIPTION
# Pull Request Template

## Description

The dashboard's Environment panel previously hardcoded all endpoint URLs as http://localhost:<port>. This PR makes the RPC, GraphQL, and Frontend labels resolve dynamically based on the host field in efctl.yaml.

| Config host  | Dashboard displays |
| ------------- | ------------- |
| 127.0.0.1 (default)  | http://localhost:9000  |
| 0.0.0.0  | http://<ethernet-ip>:9000  |
| 192.168.1.50 (custom) | http://192.168.1.50:9000 |

Changes:

* Added host field to the model struct, populated from config.Loaded.GetHost() (defaults to 127.0.0.1)
* Added resolveDisplayHost(host) — converts 127.0.0.1 → localhost, 0.0.0.0 → first non-loopback IPv4 via net.Interfaces(), anything else → passed through as-is
* Added getEthernetIP() — walks network interfaces for the first up, non-loopback IPv4 address
* Updated writeEnvConfig() to use resolveDisplayHost(m.host) for RPC (port 9000), GraphQL (port 9125), and Frontend (port 5173) URL labels
* Added net and efctl/pkg/config imports

12 new tests covering resolveDisplayHost, rpcBaseURL, getEthernetIP, initialModel host resolution, and writeEnvConfig URL rendering (localhost, custom IP, gql/fe off states)

What was intentionally NOT changed
fetchChainInfo, fetchStats, and fetchWorldEvents continue using hardcoded localhost:9000 for their internal RPC calls. These talk to the container network and don't need host awareness.

An unintended change is i updated `time.Sleep(10 * time.Second)` in `func startSuiDev` i was having startup issues with SuiDev not being ready in time and failing to request gas due to timeout changing this to `time.Sleep(30 * time.Second)` has made it far more reliable during startup.

The motivation behind the change is i develop mostly via SSH so having the services accessible outside of localhost is not only helpful but a requirement.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] `go test ./...`
- [x] Local environment deployment (`efctl env up`)

```
❯ make test
go test -count=1 ./...
?       efctl   [no test files]
ok      efctl/cmd       0.352s
?       efctl/pkg/assembly      [no test files]
ok      efctl/pkg/builder       0.011s
ok      efctl/pkg/config        0.012s
ok      efctl/pkg/container     0.070s
ok      efctl/pkg/dashboard     0.007s
ok      efctl/pkg/doctor        0.272s
ok      efctl/pkg/env   0.026s
ok      efctl/pkg/git   7.069s
ok      efctl/pkg/graphql       0.008s
?       efctl/pkg/mocks [no test files]
ok      efctl/pkg/setup 0.011s
ok      efctl/pkg/status        0.010s
ok      efctl/pkg/sui   0.004s
ok      efctl/pkg/ui    0.012s
ok      efctl/pkg/validate      0.002s
?       efctl/tools/gen-docs    [no test files]
?       efctl/tools/test-exec   [no test files]
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
