### PR TITLE
feat: support remote development startup config

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 
+	"efctl/pkg/config"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -434,4 +436,129 @@ func TestCommandTree_DoctorExists(t *testing.T) {
 		names[c.Name()] = true
 	}
 	assert.True(t, names["doctor"], "doctor command should exist")
+}
+
+// ── resolveDisplayHost ─────────────────────────────────────────────
+
+func TestResolveDisplayHost_Localhost(t *testing.T) {
+	assert.Equal(t, "localhost", resolveDisplayHost("127.0.0.1"))
+}
+
+func TestResolveDisplayHost_CustomIP(t *testing.T) {
+	assert.Equal(t, "172.0.0.1", resolveDisplayHost("172.0.0.1"))
+	assert.Equal(t, "192.168.1.100", resolveDisplayHost("192.168.1.100"))
+	assert.Equal(t, "10.0.0.5", resolveDisplayHost("10.0.0.5"))
+}
+
+func TestResolveDisplayHost_AllInterfaces(t *testing.T) {
+	// 0.0.0.0 should resolve to either the Ethernet IP or fallback to "localhost"
+	got := resolveDisplayHost("0.0.0.0")
+	assert.NotEmpty(t, got)
+	// Should be either an IP or localhost fallback
+	assert.True(t, got == "localhost" || strings.Count(got, ".") == 3,
+		"expected localhost or valid IPv4, got %q", got)
+}
+
+func TestResolveDisplayHost_Empty(t *testing.T) {
+	// An empty host is passed through as-is
+	assert.Equal(t, "", resolveDisplayHost(""))
+}
+
+// ── rpcBaseURL ─────────────────────────────────────────────────────
+
+func TestRpcBaseURL_Localhost(t *testing.T) {
+	assert.Equal(t, "http://localhost", rpcBaseURL("127.0.0.1"))
+}
+
+func TestRpcBaseURL_CustomIP(t *testing.T) {
+	assert.Equal(t, "http://172.0.0.1", rpcBaseURL("172.0.0.1"))
+}
+
+// ── getEthernetIP ──────────────────────────────────────────────────
+
+func TestGetEthernetIP_DoesNotPanic(t *testing.T) {
+	// Call it — must not panic regardless of environment
+	got := getEthernetIP()
+	// If we have network, it should be a valid IPv4 or empty
+	if got != "" {
+		assert.True(t, strings.Count(got, ".") == 3,
+			"expected valid IPv4, got %q", got)
+	}
+}
+
+// ── initialModel host resolution ───────────────────────────────────
+
+func TestInitialModel_HostDefault(t *testing.T) {
+	// Without config.Loaded set, host defaults to 127.0.0.1
+	saved := config.Loaded
+	config.Loaded = nil
+	defer func() { config.Loaded = saved }()
+
+	m := initialModel("docker", t.TempDir())
+	assert.Equal(t, "127.0.0.1", m.host)
+}
+
+func TestInitialModel_HostFromConfig(t *testing.T) {
+	saved := config.Loaded
+	config.Loaded = &config.Config{Host: "0.0.0.0"}
+	defer func() { config.Loaded = saved }()
+
+	m := initialModel("docker", t.TempDir())
+	assert.Equal(t, "0.0.0.0", m.host)
+}
+
+// ── writeEnvConfig URL rendering ───────────────────────────────────
+
+func TestWriteEnvConfig_UrlsWithLocalhostHost(t *testing.T) {
+	m := model{
+		host:       "127.0.0.1",
+		graphqlOn:  true,
+		frontendOn: true,
+		width:      120,
+		envVars:    map[string]string{},
+	}
+	var buf bytes.Buffer
+	m.writeEnvConfig(&buf, func(s string) string { return s })
+
+	out := buf.String()
+	assert.Contains(t, out, "http://localhost:9000")
+	assert.Contains(t, out, "http://localhost:9125/graphql")
+	assert.Contains(t, out, "http://localhost:5173")
+}
+
+func TestWriteEnvConfig_UrlsWithCustomHost(t *testing.T) {
+	m := model{
+		host:       "172.0.0.1",
+		graphqlOn:  true,
+		frontendOn: true,
+		width:      120,
+		envVars:    map[string]string{},
+	}
+	var buf bytes.Buffer
+	m.writeEnvConfig(&buf, func(s string) string { return s })
+
+	out := buf.String()
+	assert.Contains(t, out, "http://172.0.0.1:9000")
+	assert.Contains(t, out, "http://172.0.0.1:9125/graphql")
+	assert.Contains(t, out, "http://172.0.0.1:5173")
+}
+
+func TestWriteEnvConfig_GqlAndFeOff(t *testing.T) {
+	m := model{
+		host:       "127.0.0.1",
+		graphqlOn:  false,
+		frontendOn: false,
+		width:      120,
+		envVars:    map[string]string{},
+	}
+	var buf bytes.Buffer
+	m.writeEnvConfig(&buf, func(s string) string { return s })
+
+	out := buf.String()
+	assert.Contains(t, out, "RPC:")
+	assert.Contains(t, out, "http://localhost:9000")
+	assert.NotContains(t, out, "GraphQL:")
+	assert.NotContains(t, out, "Frontend:")
+	assert.NotContains(t, out, "9125")
+	assert.NotContains(t, out, "5173")
 }

--- a/cmd/env_dash.go
+++ b/cmd/env_dash.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -15,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"efctl/pkg/config"
 	"efctl/pkg/container"
 	"efctl/pkg/dashboard"
 	"efctl/pkg/env"
@@ -266,6 +268,59 @@ func formatCPU(cpu string) string {
 // formatMem delegates to the dashboard package.
 func formatMem(mem string) string {
 	return dashboard.FormatMem(mem)
+}
+
+// resolveDisplayHost returns the display-friendly host for URLs shown in the dashboard.
+// "127.0.0.1" → "localhost", "0.0.0.0" → ethernet IP, anything else → as-is.
+func resolveDisplayHost(host string) string {
+	if host == "127.0.0.1" {
+		return "localhost"
+	}
+	if host == "0.0.0.0" {
+		if ip := getEthernetIP(); ip != "" {
+			return ip
+		}
+		return "localhost" // fallback when no Ethernet IP found
+	}
+	return host
+}
+
+// getEthernetIP returns the first non-loopback IPv4 address of an up interface.
+func getEthernetIP() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			if ipv4 := ip.To4(); ipv4 != nil {
+				return ipv4.String()
+			}
+		}
+	}
+	return ""
+}
+
+// rpcBaseURL returns the base HTTP URL for the RPC endpoint (scheme + host).
+func rpcBaseURL(host string) string {
+	return "http://" + resolveDisplayHost(host)
 }
 
 func fetchChainInfo(client *http.Client) chainStat {
@@ -656,6 +711,7 @@ type model struct {
 	frontendOn     bool         // whether the frontend dApp container is enabled
 	worldEvents    []worldEvent // recent events from the world package
 	restarting     bool         // whether we are in the interactive restart menu
+	host           string       // bind address for container ports (from config, default 127.0.0.1)
 }
 
 func initialModel(engine string, workspace string) model {
@@ -672,6 +728,13 @@ func initialModel(engine string, workspace string) model {
 			feOn = true
 		}
 	}
+
+	// Resolve host from config (defaults to 127.0.0.1)
+	host := "127.0.0.1"
+	if config.Loaded != nil {
+		host = config.Loaded.GetHost()
+	}
+
 	return model{
 		engine:     engine,
 		workspace:  workspace,
@@ -682,6 +745,7 @@ func initialModel(engine string, workspace string) model {
 		adminAddr:  "Checking...",
 		graphqlOn:  gqlOn,
 		frontendOn: feOn,
+		host:       host,
 	}
 }
 
@@ -1324,7 +1388,7 @@ func (m model) writeEnvConfig(b *bytes.Buffer, shorten func(string) string) {
 	}
 	items := []item{
 		{label: " Network:", value: network},
-		{label: "RPC:", value: "http://localhost:9000"},
+		{label: "RPC:", value: "http://" + resolveDisplayHost(m.host) + ":9000"},
 	}
 	if v, ok := m.envVars["TENANT"]; ok {
 		items = append(items, item{label: "Tenant:", value: v})
@@ -1333,10 +1397,10 @@ func (m model) writeEnvConfig(b *bytes.Buffer, shorten func(string) string) {
 		items = append(items, item{label: "World Pkg:", value: shorten(m.worldPkgID)})
 	}
 	if m.isGraphQLEnabled() {
-		items = append(items, item{label: "GraphQL:", value: "http://localhost:9125/graphql"})
+		items = append(items, item{label: "GraphQL:", value: "http://" + resolveDisplayHost(m.host) + ":9125/graphql"})
 	}
 	if m.isFrontendEnabled() {
-		items = append(items, item{label: "Frontend:", value: "http://localhost:5173"})
+		items = append(items, item{label: "Frontend:", value: "http://" + resolveDisplayHost(m.host) + ":5173"})
 	}
 
 	var currentLine strings.Builder

--- a/efctl.yaml
+++ b/efctl.yaml
@@ -28,6 +28,15 @@ git-autocrlf: false
 # If Podman networking fails on WSL, try setting this to "docker".
 container-engine: auto-detect
 
+# Bind address for RPC, GraphQL, and frontend port mappings (default: 127.0.0.1).
+# Set to "0.0.0.0" to expose these services on all network interfaces.
+# WARNING: Remote service exposure increases your local network attack surface.
+host: "127.0.0.1"
+
+# Keep PostgreSQL bound to localhost by default. Set to true only if you
+# intentionally need remote database access; this exposes port 5432 on the host above.
+expose-postgres: false
+
 # Additional host directories to bind-mount into the container environment.
 # additional-bind-mounts:
 #   - hostPath: ./my-extension

--- a/openspec/changes/archive/2026-07-06-improve-startup-liveness-polling/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-06-improve-startup-liveness-polling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/archive/2026-07-06-improve-startup-liveness-polling/design.md
+++ b/openspec/changes/archive/2026-07-06-improve-startup-liveness-polling/design.md
@@ -1,0 +1,49 @@
+## Context
+
+`pkg/setup/start.go` currently starts the Sui development container, normalizes scripts, sleeps for 10 seconds, checks whether the container is still running, and then waits for the existing ready-log sentinel. PR #49 attempted to increase the fixed sleep to 30 seconds to reduce startup flakiness, but that adds an unconditional 20 seconds to every successful fast startup.
+
+The better model separates liveness from readiness. Liveness means the container process has started and has not immediately exited. Readiness remains the existing `WaitForLogs(..., ContainerLogReadyCtx)` gate.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace the fixed pre-readiness sleep with a small grace period followed by bounded polling.
+- Continue as soon as the Sui development container is observed running.
+- Fail early with exit code and recent logs if the container exits before readiness waiting begins.
+- Preserve the existing log-based readiness wait and startup timeout behavior.
+- Make the behavior testable without slowing tests.
+
+**Non-Goals:**
+- Proving RPC, faucet, gas, or GraphQL readiness.
+- Changing `ContainerLogReadyCtx` semantics.
+- Adding new container engine dependencies or external health probes.
+- Changing frontend or PostgreSQL startup behavior unless the same helper is later reused intentionally.
+
+## Decisions
+
+1. **Use liveness polling before existing readiness detection.**
+   - Decision: Replace the fixed 10-second sleep/check block with a short grace period and a bounded liveness polling loop that checks whether `ContainerRunning` is true or whether the container has exited.
+   - Rationale: The container can proceed immediately on fast machines while still catching immediate failures with useful diagnostics.
+   - Alternative considered: Increase the fixed sleep to 30 seconds. Rejected because it penalizes all successful startups.
+
+2. **Keep readiness based on logs.**
+   - Decision: After liveness is established, keep calling `WaitForLogs` with `ContainerLogReadyCtx` and the existing `startupTimeoutFromEnv()` context.
+   - Rationale: Running is not ready. The existing log sentinel remains the semantic readiness gate for Sui dev startup.
+   - Alternative considered: Replace log readiness with RPC/gas probing. Rejected for this change because the original scope is avoiding fixed delay, not redefining full Sui readiness.
+
+3. **Use a small grace period plus polling window.**
+   - Decision: Allow a small initial grace period, such as 500ms to 1s, before polling. Poll at a short interval, such as 250ms to 1s, up to the existing 10-second liveness budget.
+   - Rationale: This accounts for Docker/Podman state propagation without imposing a long fixed delay.
+   - Alternative considered: Poll immediately with no grace period. Rejected because a tiny grace period is a low-cost hedge against container-engine timing quirks.
+
+4. **Make timing injectable or helper-scoped for tests.**
+   - Decision: Isolate liveness waiting in a helper whose timeout/interval can be tested without real sleeps, either by passing durations or by using a minimal test-controlled polling path.
+   - Rationale: Tests should verify fast-path, exit, and timeout behavior without adding wall-clock delays.
+   - Alternative considered: Test only through `StartEnvironment`. Rejected because full startup tests would be slow and brittle.
+
+## Risks / Trade-offs
+
+- **Polling may proceed earlier than the old fixed sleep and expose latent assumptions** → Mitigate by preserving `WaitForLogs` immediately after liveness.
+- **Container engine state may briefly report not running even though startup is progressing** → Mitigate with the bounded polling window and small grace period.
+- **Failure diagnostics could change** → Mitigate by preserving exit code and recent log collection when liveness fails.
+- **Overly broad readiness claims** → Mitigate by naming this liveness polling, not full readiness probing.

--- a/openspec/changes/archive/2026-07-06-improve-startup-liveness-polling/proposal.md
+++ b/openspec/changes/archive/2026-07-06-improve-startup-liveness-polling/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The Sui development container startup path uses a fixed pre-readiness sleep before checking whether the container is still running. Increasing that fixed delay improves slow-start tolerance at the cost of penalizing every fast startup, so the startup path should proceed as soon as the container is observed alive while still failing quickly if it exits.
+
+## What Changes
+
+- Replace the fixed pre-readiness startup delay with a short grace period followed by bounded liveness polling.
+- Proceed immediately once the Sui development container is observed running.
+- Fail early with exit code and recent logs if the Sui development container exits during the liveness window.
+- Preserve the existing log-based readiness gate after liveness is established.
+- Keep startup readiness and liveness distinct: liveness means the container process is alive; readiness remains based on the existing ready-log sentinel.
+- Add tests for fast-path startup, early container exit, and liveness timeout behavior.
+
+## Capabilities
+
+### New Capabilities
+- `startup-liveness-polling`: Bounded Sui development container liveness polling before existing log-based readiness detection.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected code: Sui development environment startup flow in `pkg/setup/start.go`, setup mocks/tests, and any helper functions introduced for polling behavior.
+- Affected behavior: fast successful starts no longer wait an unconditional fixed delay, while failed starts still report useful diagnostics.
+- Dependencies: no new third-party dependencies expected.

--- a/openspec/changes/archive/2026-07-06-improve-startup-liveness-polling/specs/startup-liveness-polling/spec.md
+++ b/openspec/changes/archive/2026-07-06-improve-startup-liveness-polling/specs/startup-liveness-polling/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Sui startup liveness polling
+The system SHALL use bounded liveness polling before waiting for Sui development container readiness.
+
+#### Scenario: Fast liveness success
+- **WHEN** the Sui development container is observed running during the liveness polling window
+- **THEN** startup proceeds to the existing log-based readiness wait without waiting for the full liveness window
+
+#### Scenario: Initial grace period
+- **WHEN** the Sui development container has just been started
+- **THEN** the system waits only a short grace period before beginning liveness polling
+
+#### Scenario: Container exits during liveness polling
+- **WHEN** the Sui development container exits before it is observed running
+- **THEN** startup fails with the container exit code and recent container logs
+
+#### Scenario: Liveness timeout
+- **WHEN** the Sui development container is not observed running before the liveness polling window expires
+- **THEN** startup fails with diagnostics that include recent container logs and exit-code information when available
+
+### Requirement: Log-based readiness preserved
+The system SHALL preserve the existing log-based Sui readiness gate after liveness is established.
+
+#### Scenario: Liveness succeeds before readiness
+- **WHEN** the Sui development container is observed running
+- **THEN** the system continues to wait for the existing ready-log sentinel before treating Sui startup as ready
+
+#### Scenario: Ready-log timeout
+- **WHEN** the ready-log sentinel is not observed before the configured startup timeout
+- **THEN** startup fails using the existing readiness timeout diagnostics
+
+### Requirement: No unconditional extended startup delay
+The system SHALL NOT add an unconditional extended fixed delay before Sui readiness waiting.
+
+#### Scenario: Avoid fixed 30-second delay
+- **WHEN** the Sui development container is observed running quickly
+- **THEN** startup does not wait an unconditional 30 seconds before starting the ready-log wait
+
+#### Scenario: Preserve fast startup path
+- **WHEN** liveness is established quickly and the ready-log sentinel appears quickly
+- **THEN** startup completes without waiting for any unused liveness budget

--- a/openspec/changes/archive/2026-07-06-improve-startup-liveness-polling/tasks.md
+++ b/openspec/changes/archive/2026-07-06-improve-startup-liveness-polling/tasks.md
@@ -1,0 +1,28 @@
+## 1. Startup Flow Analysis
+
+- [x] 1.1 Review `pkg/setup/start.go` around Sui development container startup, fixed sleep, running check, and ready-log wait.
+- [x] 1.2 Review existing setup/container mocks to identify the smallest test seam for liveness polling.
+- [x] 1.3 Confirm existing `WaitForLogs(..., ContainerLogReadyCtx)` readiness behavior remains unchanged.
+
+## 2. Liveness Polling Implementation
+
+- [x] 2.1 Introduce a helper for bounded Sui container liveness polling with configurable grace period, poll interval, and timeout.
+- [x] 2.2 Make the helper proceed as soon as `ContainerRunning(container.ContainerSuiPlayground)` returns true.
+- [x] 2.3 Make the helper fail with exit code and recent logs when the container exits or fails to become running within the liveness window.
+- [x] 2.4 Replace the fixed pre-readiness sleep/running-check block in `startSuiDev` with the liveness polling helper.
+- [x] 2.5 Preserve the existing log-based readiness wait and startup timeout after liveness succeeds.
+
+## 3. Tests
+
+- [x] 3.1 Add unit tests for fast-path liveness success without waiting for the full liveness timeout.
+- [x] 3.2 Add unit tests for container exit during liveness polling, including exit-code/log diagnostics.
+- [x] 3.3 Add unit tests for liveness timeout diagnostics when the container never becomes running.
+- [x] 3.4 Add tests proving `WaitForLogs` is still called after liveness succeeds.
+- [x] 3.5 Ensure tests avoid real multi-second sleeps by using small durations or a testable polling seam.
+
+## 4. Verification
+
+- [x] 4.1 Run `go test ./...` and fix failures.
+- [x] 4.2 Run formatting and repository pre-commit checks.
+- [x] 4.3 Manually inspect startup code to verify no unconditional 30-second delay remains.
+- [x] 4.4 Confirm diagnostics still include recent logs and exit-code information for early Sui container failures.

--- a/openspec/changes/archive/2026-07-06-remote-development-host-config/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-06-remote-development-host-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/archive/2026-07-06-remote-development-host-config/design.md
+++ b/openspec/changes/archive/2026-07-06-remote-development-host-config/design.md
@@ -1,0 +1,57 @@
+## Context
+
+`efctl` currently publishes development environment ports on localhost-oriented bindings and the dashboard displays hardcoded localhost URLs. PR #49 from `setkeh:add-host-config` introduces a `host` config value and dynamic dashboard labels, which enables remote development over SSH or LAN access. That implementation also applies the configured host to PostgreSQL, so `host: "0.0.0.0"` can expose port 5432 on all interfaces.
+
+This change will create the implementation branch `feat/remote-development`, incorporate the host configuration work, and tighten the design so remote-facing service endpoints can be exposed without accidentally exposing PostgreSQL.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a safe remote-development host configuration that defaults to localhost-only behavior.
+- Allow RPC, GraphQL, and frontend ports to bind to a configured host such as `127.0.0.1`, `0.0.0.0`, or a specific interface address.
+- Keep PostgreSQL bound to localhost by default, regardless of the service host setting.
+- Provide an explicit opt-in for PostgreSQL host exposure when needed.
+- Render dashboard URLs using display-friendly host resolution.
+- Trim and validate host-related config before container creation, before values can be formatted into Docker/Podman `-p` arguments.
+- Preserve existing startup timing by reverting the unrelated fixed sleep increase from the upstream branch unless it is replaced by readiness polling in a separate change.
+- Cover the behavior with unit tests for config, container args, startup wiring, startup delay preservation, and dashboard output.
+
+**Non-Goals:**
+- Adding authentication, TLS, firewall management, or production hardening for exposed services.
+- Changing internal container-to-container networking or service discovery.
+- Reworking startup readiness beyond reverting or isolating unrelated fixed sleep changes.
+- Supporting arbitrary URL schemes; exposed dashboard links remain HTTP.
+
+## Decisions
+
+1. **Separate service host from PostgreSQL exposure.**
+   - Decision: Use the configured service host for RPC, GraphQL, and frontend port bindings, but use `127.0.0.1` for PostgreSQL unless an explicit PostgreSQL exposure flag/config is enabled.
+   - Rationale: The main remote-development use case needs application endpoints, not database exposure. Database exposure has higher security impact and should require intent.
+   - Alternative considered: Apply one `host` setting to all ports. Rejected because it caused accidental PostgreSQL exposure.
+
+2. **Use explicit PostgreSQL opt-in rather than implicit inference.**
+   - Decision: Add a clear config field and/or CLI flag for exposing PostgreSQL, with naming that communicates risk, such as `expose-postgres: true` or an equivalent env/flag path accepted by existing CLI patterns.
+   - Rationale: Operators must make a deliberate choice before binding port 5432 beyond localhost.
+   - Alternative considered: Expose PostgreSQL only when GraphQL is enabled. Rejected because GraphQL requires the database internally, but external host access is not required.
+
+3. **Validate bind hosts during config validation.**
+   - Decision: `GetHost()` and related accessors must trim whitespace, and `Validate()` must reject empty-after-trim, malformed, or unsupported host values. Accept `localhost`, valid IPv4 addresses, and valid DNS hostnames. IPv6 may be accepted only if the implementation also formats container port bindings with correct IPv6 bracket syntax; otherwise reject IPv6 with a clear error.
+   - Rationale: Failing early produces clearer errors than passing malformed values into `fmt.Sprintf("%s:%d:%d/tcp", host, hostPort, containerPort)` and then receiving Docker/Podman errors.
+   - Alternative considered: Let the container engine reject invalid host strings. Rejected because errors would be later and less actionable.
+
+4. **Resolve display host independently from bind host.**
+   - Decision: Keep binding semantics separate from dashboard display semantics. `127.0.0.1` displays as `localhost`; `0.0.0.0` displays as a detected non-loopback IPv4 address when available, falling back to `localhost`.
+   - Rationale: `0.0.0.0` is a bind address, not a client URL. The dashboard should show a URL users can open.
+   - Alternative considered: Display `0.0.0.0` directly. Rejected because it is less useful as a browser/client endpoint.
+
+5. **Keep unrelated startup timing out of this change.**
+   - Decision: Revert the accidental `time.Sleep(10 * time.Second)` to `time.Sleep(30 * time.Second)` change from the upstream branch during intake. If startup reliability needs improvement, handle it separately with readiness polling/backoff that does not penalize fast startups.
+   - Rationale: A fixed 30-second sleep increases every startup path by 20 seconds and is unrelated to remote host binding.
+
+## Risks / Trade-offs
+
+- **Remote service exposure increases local network attack surface** → Mitigate with localhost default, explicit documentation, and no authentication claims.
+- **PostgreSQL may still be intentionally exposed insecurely** → Mitigate by requiring explicit opt-in and documenting the risk in config comments/help text.
+- **Host validation may reject edge-case container-engine formats** → Mitigate with focused validation tests and support for common IPv4/hostname/local cases first.
+- **Network interface detection for display can pick an unexpected address** → Mitigate by treating it as display-only and allowing custom host values for deterministic output.
+- **Bringing in an external branch may include unrelated changes** → Mitigate by reviewing the diff and excluding unrelated startup sleep changes unless separately justified.

--- a/openspec/changes/archive/2026-07-06-remote-development-host-config/proposal.md
+++ b/openspec/changes/archive/2026-07-06-remote-development-host-config/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Developers running `efctl` over SSH or from another machine need environment endpoints to bind beyond localhost and for the dashboard to show reachable URLs. The current upstream PR for host configuration provides that flexibility, but it can unintentionally expose PostgreSQL when binding services to all interfaces.
+
+## What Changes
+
+- Create a working branch named `feat/remote-development` from the repository base.
+- Bring in the remote-development host configuration changes from `setkeh:add-host-config`.
+- Add a configurable host/bind address for externally reachable development services, defaulting to localhost-compatible behavior.
+- Update dashboard endpoint labels to display URLs based on the configured host, including resolving `0.0.0.0` to a useful local network address for display.
+- Restrict PostgreSQL host exposure by default even when service endpoints are bound to `0.0.0.0` or a custom address.
+- Add an explicit opt-in flag/configuration path for exposing PostgreSQL when a developer intentionally needs remote database access.
+- Trim and validate host-related configuration so invalid bind addresses fail early with actionable errors before they reach container port argument formatting.
+- Reject empty-after-trim, malformed, or unsupported host values; support `localhost`, valid IPv4 addresses, valid hostnames, and IPv6 only if implemented with correct container port syntax.
+- Revert the unrelated `10s` to `30s` startup sleep from `setkeh:add-host-config`, unless replacing it with readiness polling/backoff in a separate justified change.
+- Add or update tests for default local-only behavior, remote service binding, PostgreSQL restriction, explicit PostgreSQL exposure, host validation, startup delay preservation, and dashboard URL rendering.
+
+## Capabilities
+
+### New Capabilities
+- `remote-development-host-config`: Configurable remote-development service binding and dashboard endpoint display with safe PostgreSQL exposure controls.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected code: configuration loading/validation, config template/default YAML, container port binding, service container constructors, environment startup, dashboard environment panel, startup timing preservation, and tests.
+- Affected CLI behavior: `efctl env up` and `efctl env dash` should continue to default to localhost-safe behavior while allowing explicit remote service access.
+- Security impact: reduces accidental database exposure by keeping PostgreSQL local-only unless explicitly enabled.
+- Dependencies: no new third-party dependencies expected.

--- a/openspec/changes/archive/2026-07-06-remote-development-host-config/specs/remote-development-host-config/spec.md
+++ b/openspec/changes/archive/2026-07-06-remote-development-host-config/specs/remote-development-host-config/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Configurable service bind host
+The system SHALL allow development service endpoints to bind to a configured host address while preserving localhost-only behavior by default.
+
+#### Scenario: Default service host
+- **WHEN** no service host is configured
+- **THEN** RPC, GraphQL, and frontend host port bindings use `127.0.0.1`
+
+#### Scenario: Remote service host
+- **WHEN** the service host is configured as `0.0.0.0`
+- **THEN** RPC, GraphQL, and frontend host port bindings use `0.0.0.0`
+
+#### Scenario: Custom service host
+- **WHEN** the service host is configured as a valid custom address
+- **THEN** RPC, GraphQL, and frontend host port bindings use that custom address
+
+### Requirement: PostgreSQL exposure restricted by default
+The system SHALL keep PostgreSQL bound to localhost unless PostgreSQL exposure is explicitly enabled.
+
+#### Scenario: Remote service host without PostgreSQL exposure
+- **WHEN** the service host is configured as `0.0.0.0` and PostgreSQL exposure is not enabled
+- **THEN** PostgreSQL host port binding uses `127.0.0.1`
+
+#### Scenario: Custom service host without PostgreSQL exposure
+- **WHEN** the service host is configured as a custom non-localhost address and PostgreSQL exposure is not enabled
+- **THEN** PostgreSQL host port binding uses `127.0.0.1`
+
+#### Scenario: Explicit PostgreSQL exposure
+- **WHEN** PostgreSQL exposure is explicitly enabled and the service host is configured as a valid remote address
+- **THEN** PostgreSQL host port binding uses the configured remote address
+
+### Requirement: Host configuration validation
+The system SHALL trim and validate host-related configuration before creating containers or formatting container port arguments.
+
+#### Scenario: Valid host configuration
+- **WHEN** the configured host values are `localhost`, valid IPv4 addresses, valid DNS hostnames, or supported IPv6 values with correct port binding syntax
+- **THEN** configuration validation succeeds
+
+#### Scenario: Whitespace host configuration
+- **WHEN** a configured host value has leading or trailing whitespace around an otherwise valid value
+- **THEN** host accessors return the trimmed value and configuration validation succeeds
+
+#### Scenario: Empty host configuration
+- **WHEN** a configured host value is empty after trimming
+- **THEN** configuration validation fails with an actionable error before container creation
+
+#### Scenario: Malformed host configuration
+- **WHEN** a configured host value is malformed or unsupported
+- **THEN** configuration validation fails with an actionable error before container creation
+
+#### Scenario: Unsupported IPv6 host configuration
+- **WHEN** a configured host value is IPv6 and the implementation does not support correct IPv6 container port syntax
+- **THEN** configuration validation fails with an actionable error before container creation
+
+### Requirement: Dashboard displays reachable endpoint URLs
+The dashboard SHALL display endpoint URLs derived from the configured service host rather than hardcoded localhost values.
+
+#### Scenario: Localhost dashboard URLs
+- **WHEN** the service host is `127.0.0.1`
+- **THEN** the dashboard displays RPC, GraphQL, and frontend URLs using `localhost`
+
+#### Scenario: All-interfaces dashboard URLs
+- **WHEN** the service host is `0.0.0.0` and a non-loopback IPv4 address is available
+- **THEN** the dashboard displays RPC, GraphQL, and frontend URLs using the detected non-loopback IPv4 address
+
+#### Scenario: All-interfaces dashboard fallback
+- **WHEN** the service host is `0.0.0.0` and no non-loopback IPv4 address is available
+- **THEN** the dashboard displays RPC, GraphQL, and frontend URLs using `localhost`
+
+#### Scenario: Custom host dashboard URLs
+- **WHEN** the service host is a valid custom host
+- **THEN** the dashboard displays RPC, GraphQL, and frontend URLs using that custom host
+
+### Requirement: Remote-development implementation branch
+The implementation SHALL happen on a repository branch named `feat/remote-development` and incorporate the reviewed host-configuration changes from `setkeh:add-host-config`.
+
+#### Scenario: Implementation branch exists
+- **WHEN** implementation starts
+- **THEN** the repository has a working branch named `feat/remote-development`
+
+#### Scenario: External host configuration changes incorporated safely
+- **WHEN** changes from `setkeh:add-host-config` are brought into the implementation branch
+- **THEN** unrelated changes are excluded or separately justified, and PostgreSQL exposure remains restricted unless explicitly enabled
+
+#### Scenario: Unrelated fixed startup delay excluded
+- **WHEN** changes from `setkeh:add-host-config` are brought into the implementation branch
+- **THEN** the unrelated `time.Sleep(10 * time.Second)` to `time.Sleep(30 * time.Second)` change is not included in this change
+
+#### Scenario: Startup readiness improvement handled separately
+- **WHEN** startup reliability needs improvement
+- **THEN** it is implemented as readiness polling/backoff in a separate justified change rather than as an unconditional fixed 30-second delay

--- a/openspec/changes/archive/2026-07-06-remote-development-host-config/tasks.md
+++ b/openspec/changes/archive/2026-07-06-remote-development-host-config/tasks.md
@@ -1,0 +1,43 @@
+## 1. Branch and Upstream Change Intake
+
+- [x] 1.1 Create or switch to repository branch `feat/remote-development` from the current base branch.
+- [x] 1.2 Fetch `setkeh:add-host-config` and inspect the diff against the base branch.
+- [x] 1.3 Incorporate the host configuration, dashboard URL, container binding, and test changes from `setkeh:add-host-config`.
+- [x] 1.4 Exclude or revert the unrelated `time.Sleep(10 * time.Second)` to `time.Sleep(30 * time.Second)` startup delay change from the upstream branch.
+
+## 2. Configuration Model and Validation
+
+- [x] 2.1 Add service host configuration with default `127.0.0.1` in the config model and template YAML.
+- [x] 2.2 Add explicit PostgreSQL exposure configuration or flag that defaults to disabled.
+- [x] 2.3 Trim service host and PostgreSQL exposure host values in config accessors before use.
+- [x] 2.4 Validate service host and PostgreSQL exposure host values during config validation, accepting `localhost`, valid IPv4 addresses, and valid hostnames.
+- [x] 2.5 Reject empty-after-trim, malformed, unsupported, and IPv6 values unless IPv6 port formatting is explicitly implemented.
+- [x] 2.6 Add config tests for default host, trimmed host, remote host, custom hostname, explicit PostgreSQL exposure, invalid host values, and unsupported IPv6 behavior.
+
+## 3. Container Binding Behavior
+
+- [x] 3.1 Thread service host configuration into RPC, GraphQL, and frontend container port bindings.
+- [x] 3.2 Keep PostgreSQL host binding on `127.0.0.1` when PostgreSQL exposure is not enabled.
+- [x] 3.3 Bind PostgreSQL to the configured remote host only when explicit exposure is enabled.
+- [x] 3.4 Add container argument tests covering service ports, default PostgreSQL restriction, and explicit PostgreSQL exposure.
+
+## 4. Dashboard Endpoint Display
+
+- [x] 4.1 Add display-host resolution that renders `127.0.0.1` as `localhost`.
+- [x] 4.2 Render `0.0.0.0` dashboard URLs using a detected non-loopback IPv4 address with a localhost fallback.
+- [x] 4.3 Render custom host dashboard URLs without replacing the configured custom host.
+- [x] 4.4 Add dashboard tests for RPC, GraphQL, frontend, disabled optional services, and display-host fallback behavior.
+
+## 5. Environment Startup Wiring
+
+- [x] 5.1 Pass validated service host and PostgreSQL exposure settings through environment startup to service constructors.
+- [x] 5.2 Ensure internal container networking and internal RPC fetch paths continue to use existing local/container network assumptions.
+- [x] 5.3 Add setup tests or mock assertions proving PostgreSQL remains local-only unless exposure is enabled.
+
+## 6. Verification
+
+- [x] 6.1 Run `go test ./...` and fix failures.
+- [x] 6.2 Run formatting and pre-commit checks required by the repository.
+- [x] 6.3 Verify the Sui startup fixed sleep remains at the original 10 seconds unless replaced by separately scoped readiness polling.
+- [x] 6.4 Manually review generated container port args for localhost default, `0.0.0.0` service exposure, explicit PostgreSQL exposure, and rejected invalid hosts.
+- [x] 6.5 Document any user-facing config comments or help text warning that remote service exposure increases local network attack surface.

--- a/openspec/specs/remote-development-host-config/spec.md
+++ b/openspec/specs/remote-development-host-config/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Configurable service bind host
+The system SHALL allow development service endpoints to bind to a configured host address while preserving localhost-only behavior by default.
+
+#### Scenario: Default service host
+- **WHEN** no service host is configured
+- **THEN** RPC, GraphQL, and frontend host port bindings use `127.0.0.1`
+
+#### Scenario: Remote service host
+- **WHEN** the service host is configured as `0.0.0.0`
+- **THEN** RPC, GraphQL, and frontend host port bindings use `0.0.0.0`
+
+#### Scenario: Custom service host
+- **WHEN** the service host is configured as a valid custom address
+- **THEN** RPC, GraphQL, and frontend host port bindings use that custom address
+
+### Requirement: PostgreSQL exposure restricted by default
+The system SHALL keep PostgreSQL bound to localhost unless PostgreSQL exposure is explicitly enabled.
+
+#### Scenario: Remote service host without PostgreSQL exposure
+- **WHEN** the service host is configured as `0.0.0.0` and PostgreSQL exposure is not enabled
+- **THEN** PostgreSQL host port binding uses `127.0.0.1`
+
+#### Scenario: Custom service host without PostgreSQL exposure
+- **WHEN** the service host is configured as a custom non-localhost address and PostgreSQL exposure is not enabled
+- **THEN** PostgreSQL host port binding uses `127.0.0.1`
+
+#### Scenario: Explicit PostgreSQL exposure
+- **WHEN** PostgreSQL exposure is explicitly enabled and the service host is configured as a valid remote address
+- **THEN** PostgreSQL host port binding uses the configured remote address
+
+### Requirement: Host configuration validation
+The system SHALL trim and validate host-related configuration before creating containers or formatting container port arguments.
+
+#### Scenario: Valid host configuration
+- **WHEN** the configured host values are `localhost`, valid IPv4 addresses, valid DNS hostnames, or supported IPv6 values with correct port binding syntax
+- **THEN** configuration validation succeeds
+
+#### Scenario: Whitespace host configuration
+- **WHEN** a configured host value has leading or trailing whitespace around an otherwise valid value
+- **THEN** host accessors return the trimmed value and configuration validation succeeds
+
+#### Scenario: Empty host configuration
+- **WHEN** a configured host value is empty after trimming
+- **THEN** configuration validation fails with an actionable error before container creation
+
+#### Scenario: Malformed host configuration
+- **WHEN** a configured host value is malformed or unsupported
+- **THEN** configuration validation fails with an actionable error before container creation
+
+#### Scenario: Unsupported IPv6 host configuration
+- **WHEN** a configured host value is IPv6 and the implementation does not support correct IPv6 container port syntax
+- **THEN** configuration validation fails with an actionable error before container creation
+
+### Requirement: Dashboard displays reachable endpoint URLs
+The dashboard SHALL display endpoint URLs derived from the configured service host rather than hardcoded localhost values.
+
+#### Scenario: Localhost dashboard URLs
+- **WHEN** the service host is `127.0.0.1`
+- **THEN** the dashboard displays RPC, GraphQL, and frontend URLs using `localhost`
+
+#### Scenario: All-interfaces dashboard URLs
+- **WHEN** the service host is `0.0.0.0` and a non-loopback IPv4 address is available
+- **THEN** the dashboard displays RPC, GraphQL, and frontend URLs using the detected non-loopback IPv4 address
+
+#### Scenario: All-interfaces dashboard fallback
+- **WHEN** the service host is `0.0.0.0` and no non-loopback IPv4 address is available
+- **THEN** the dashboard displays RPC, GraphQL, and frontend URLs using `localhost`
+
+#### Scenario: Custom host dashboard URLs
+- **WHEN** the service host is a valid custom host
+- **THEN** the dashboard displays RPC, GraphQL, and frontend URLs using that custom host
+
+### Requirement: Remote-development implementation branch
+The implementation SHALL happen on a repository branch named `feat/remote-development` and incorporate the reviewed host-configuration changes from `setkeh:add-host-config`.
+
+#### Scenario: Implementation branch exists
+- **WHEN** implementation starts
+- **THEN** the repository has a working branch named `feat/remote-development`
+
+#### Scenario: External host configuration changes incorporated safely
+- **WHEN** changes from `setkeh:add-host-config` are brought into the implementation branch
+- **THEN** unrelated changes are excluded or separately justified, and PostgreSQL exposure remains restricted unless explicitly enabled
+
+#### Scenario: Unrelated fixed startup delay excluded
+- **WHEN** changes from `setkeh:add-host-config` are brought into the implementation branch
+- **THEN** the unrelated `time.Sleep(10 * time.Second)` to `time.Sleep(30 * time.Second)` change is not included in this change
+
+#### Scenario: Startup readiness improvement handled separately
+- **WHEN** startup reliability needs improvement
+- **THEN** it is implemented as readiness polling/backoff in a separate justified change rather than as an unconditional fixed 30-second delay

--- a/openspec/specs/startup-liveness-polling/spec.md
+++ b/openspec/specs/startup-liveness-polling/spec.md
@@ -1,0 +1,44 @@
+# startup-liveness-polling Specification
+
+## Requirements
+
+### Requirement: Sui startup liveness polling
+The system SHALL use bounded liveness polling before waiting for Sui development container readiness.
+
+#### Scenario: Fast liveness success
+- **WHEN** the Sui development container is observed running during the liveness polling window
+- **THEN** startup proceeds to the existing log-based readiness wait without waiting for the full liveness window
+
+#### Scenario: Initial grace period
+- **WHEN** the Sui development container has just been started
+- **THEN** the system waits only a short grace period before beginning liveness polling
+
+#### Scenario: Container exits during liveness polling
+- **WHEN** the Sui development container exits before it is observed running
+- **THEN** startup fails with the container exit code and recent container logs
+
+#### Scenario: Liveness timeout
+- **WHEN** the Sui development container is not observed running before the liveness polling window expires
+- **THEN** startup fails with diagnostics that include recent container logs and exit-code information when available
+
+### Requirement: Log-based readiness preserved
+The system SHALL preserve the existing log-based Sui readiness gate after liveness is established.
+
+#### Scenario: Liveness succeeds before readiness
+- **WHEN** the Sui development container is observed running
+- **THEN** the system continues to wait for the existing ready-log sentinel before treating Sui startup as ready
+
+#### Scenario: Ready-log timeout
+- **WHEN** the ready-log sentinel is not observed before the configured startup timeout
+- **THEN** startup fails using the existing readiness timeout diagnostics
+
+### Requirement: No unconditional extended startup delay
+The system SHALL NOT add an unconditional extended fixed delay before Sui readiness waiting.
+
+#### Scenario: Avoid fixed 30-second delay
+- **WHEN** the Sui development container is observed running quickly
+- **THEN** startup does not wait an unconditional 30 seconds before starting the ready-log wait
+
+#### Scenario: Preserve fast startup path
+- **WHEN** liveness is established quickly and the ready-log sentinel appears quickly
+- **THEN** startup completes without waiting for any unused liveness budget

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -13,6 +14,7 @@ import (
 // safeBranchRe matches valid git branch names (alphanumeric, hyphens, underscores, dots, slashes).
 var safeBranchRe = regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`)
 var safeMountIdentifierRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+var safeHostnameRe = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`)
 
 // AdditionalBindMount represents a user-configured host directory that should be
 // bind-mounted into the container environment.
@@ -41,6 +43,8 @@ type Config struct {
 	GitAutoCRLF           *bool                 `yaml:"git-autocrlf"`
 	ContainerEngine       string                `yaml:"container-engine"`
 	AdditionalBindMounts  []AdditionalBindMount `yaml:"additional-bind-mounts"`
+	Host                  string                `yaml:"host"`
+	ExposePostgres        bool                  `yaml:"expose-postgres"`
 
 	// Internal field to track if a config file was actually loaded
 	configFileLoaded bool
@@ -143,6 +147,20 @@ func Load(path string) (*Config, error) {
 
 // Validate checks that all configured values are safe and well-formed.
 func (c *Config) Validate() error {
+	for _, validate := range []func(*Config) error{
+		validateGitURLs,
+		validateGitRefs,
+		validateConfiguredHost,
+		validateAdditionalBindMounts,
+	} {
+		if err := validate(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateGitURLs(c *Config) error {
 	// Validate git URLs — only https:// is allowed to prevent git:// / ssh:// / file:// protocol abuse
 	for _, entry := range []struct {
 		name, url string
@@ -150,13 +168,14 @@ func (c *Config) Validate() error {
 		{"world-contracts-url", c.WorldContractsURL},
 		{"builder-scaffold-url", c.BuilderScaffoldURL},
 	} {
-		if entry.url != "" {
-			if !strings.HasPrefix(entry.url, "https://") {
-				return fmt.Errorf("%s must use https:// scheme, got: %s", entry.name, entry.url)
-			}
+		if entry.url != "" && !strings.HasPrefix(entry.url, "https://") {
+			return fmt.Errorf("%s must use https:// scheme, got: %s", entry.name, entry.url)
 		}
 	}
+	return nil
+}
 
+func validateGitRefs(c *Config) error {
 	// Validate ref names — prevent argument injection via git checkout
 	for _, entry := range []struct {
 		name, ref string
@@ -164,44 +183,90 @@ func (c *Config) Validate() error {
 		{"world-contracts-ref", c.GetWorldContractsRef()},
 		{"builder-scaffold-ref", c.GetBuilderScaffoldRef()},
 	} {
-		if entry.ref != "" {
-			// Allow commit hashes (40-character hex)
-			isCommit, _ := regexp.MatchString(`^[0-9a-fA-F]{40}$`, entry.ref)
-			if !isCommit {
-				if !safeBranchRe.MatchString(entry.ref) {
-					return fmt.Errorf("%s contains invalid characters: %s (allowed: alphanumeric, hyphens, underscores, dots, slashes, or 40-char commit hash)", entry.name, entry.ref)
-				}
-			}
-			// Reject refs starting with "-" to prevent argument injection
-			if strings.HasPrefix(entry.ref, "-") {
-				return fmt.Errorf("%s must not start with a hyphen: %s", entry.name, entry.ref)
-			}
+		if err := validateGitRef(entry.name, entry.ref); err != nil {
+			return err
 		}
 	}
+	return nil
+}
 
+func validateGitRef(name, ref string) error {
+	if ref == "" {
+		return nil
+	}
+	isCommit, _ := regexp.MatchString(`^[0-9a-fA-F]{40}$`, ref)
+	if !isCommit && !safeBranchRe.MatchString(ref) {
+		return fmt.Errorf("%s contains invalid characters: %s (allowed: alphanumeric, hyphens, underscores, dots, slashes, or 40-char commit hash)", name, ref)
+	}
+	if strings.HasPrefix(ref, "-") {
+		return fmt.Errorf("%s must not start with a hyphen: %s", name, ref)
+	}
+	return nil
+}
+
+func validateConfiguredHost(c *Config) error {
+	return validateHostValue("host", c.Host, c.Host != "")
+}
+
+func validateAdditionalBindMounts(c *Config) error {
 	seenIdentifiers := make(map[string]struct{}, len(c.AdditionalBindMounts))
 	for index, mount := range c.AdditionalBindMounts {
-		hostPath := strings.TrimSpace(mount.HostPath)
-		identifier := strings.TrimSpace(mount.Identifier)
-
-		if hostPath == "" {
-			return fmt.Errorf("additional-bind-mounts[%d].hostPath must not be empty", index)
+		if err := validateAdditionalBindMount(index, mount, seenIdentifiers); err != nil {
+			return err
 		}
-		if strings.ContainsRune(hostPath, 0) {
-			return fmt.Errorf("additional-bind-mounts[%d].hostPath contains null bytes", index)
-		}
-		if identifier == "" {
-			return fmt.Errorf("additional-bind-mounts[%d].identifier must not be empty", index)
-		}
-		if !safeMountIdentifierRe.MatchString(identifier) {
-			return fmt.Errorf("additional-bind-mounts[%d].identifier contains invalid characters: %s", index, identifier)
-		}
-		if _, exists := seenIdentifiers[identifier]; exists {
-			return fmt.Errorf("additional-bind-mounts[%d].identifier duplicates %q", index, identifier)
-		}
-		seenIdentifiers[identifier] = struct{}{}
 	}
+	return nil
+}
 
+func validateAdditionalBindMount(index int, mount AdditionalBindMount, seenIdentifiers map[string]struct{}) error {
+	hostPath := strings.TrimSpace(mount.HostPath)
+	identifier := strings.TrimSpace(mount.Identifier)
+
+	if hostPath == "" {
+		return fmt.Errorf("additional-bind-mounts[%d].hostPath must not be empty", index)
+	}
+	if strings.ContainsRune(hostPath, 0) {
+		return fmt.Errorf("additional-bind-mounts[%d].hostPath contains null bytes", index)
+	}
+	if identifier == "" {
+		return fmt.Errorf("additional-bind-mounts[%d].identifier must not be empty", index)
+	}
+	if !safeMountIdentifierRe.MatchString(identifier) {
+		return fmt.Errorf("additional-bind-mounts[%d].identifier contains invalid characters: %s", index, identifier)
+	}
+	if _, exists := seenIdentifiers[identifier]; exists {
+		return fmt.Errorf("additional-bind-mounts[%d].identifier duplicates %q", index, identifier)
+	}
+	seenIdentifiers[identifier] = struct{}{}
+	return nil
+}
+
+func validateHostValue(name string, value string, explicitlyConfigured bool) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		if explicitlyConfigured {
+			return fmt.Errorf("%s must not be empty", name)
+		}
+		return nil
+	}
+	if trimmed != value {
+		value = trimmed
+	}
+	if strings.EqualFold(value, "localhost") {
+		return nil
+	}
+	if strings.Contains(value, ":") {
+		return fmt.Errorf("%s does not support IPv6 host values yet: %s", name, value)
+	}
+	if ip := net.ParseIP(value); ip != nil {
+		if ip.To4() == nil {
+			return fmt.Errorf("%s does not support IPv6 host values yet: %s", name, value)
+		}
+		return nil
+	}
+	if len(value) > 253 || !safeHostnameRe.MatchString(value) {
+		return fmt.Errorf("%s must be localhost, a valid IPv4 address, or a valid hostname: %s", name, value)
+	}
 	return nil
 }
 
@@ -317,6 +382,25 @@ func (c *Config) GetContainerEngine() string {
 		return c.ContainerEngine
 	}
 	return "auto-detect"
+}
+
+// GetHost returns the configured bind address for service container ports, defaulting to 127.0.0.1.
+func (c *Config) GetHost() string {
+	if c != nil {
+		if host := strings.TrimSpace(c.Host); host != "" {
+			return host
+		}
+	}
+	return "127.0.0.1"
+}
+
+// GetPostgresHost returns the PostgreSQL bind address. PostgreSQL stays local-only
+// unless explicitly exposed, in which case it uses the validated service host.
+func (c *Config) GetPostgresHost() string {
+	if c != nil && c.ExposePostgres {
+		return c.GetHost()
+	}
+	return "127.0.0.1"
 }
 
 // WasLoaded returns true if a config file was successfully loaded (not just defaulted).

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -141,6 +141,71 @@ func TestValidate_RejectsInvalidAdditionalBindMountIdentifier(t *testing.T) {
 	assert.Contains(t, err.Error(), "identifier contains invalid characters")
 }
 
+func TestGetContainerEngine_Default(t *testing.T) {
+	cfg := &Config{}
+	assert.Equal(t, "auto-detect", cfg.GetContainerEngine())
+}
+
+func TestGetContainerEngine_Custom(t *testing.T) {
+	cfg := &Config{ContainerEngine: "podman"}
+	assert.Equal(t, "podman", cfg.GetContainerEngine())
+}
+
+func TestGetHost_Default(t *testing.T) {
+	cfg := &Config{}
+	assert.Equal(t, "127.0.0.1", cfg.GetHost())
+}
+
+func TestGetHost_Custom(t *testing.T) {
+	cfg := &Config{Host: "0.0.0.0"}
+	assert.Equal(t, "0.0.0.0", cfg.GetHost())
+}
+
+func TestGetHost_TrimsWhitespace(t *testing.T) {
+	cfg := &Config{Host: "  devbox.local  "}
+	assert.Equal(t, "devbox.local", cfg.GetHost())
+}
+
+func TestValidate_AcceptsHostValues(t *testing.T) {
+	for _, host := range []string{"localhost", "127.0.0.1", "0.0.0.0", "192.168.1.10", "devbox.local", "my-host"} {
+		t.Run(host, func(t *testing.T) {
+			cfg := &Config{Host: host}
+			require.NoError(t, cfg.Validate())
+		})
+	}
+}
+
+func TestValidate_AcceptsTrimmedHostValue(t *testing.T) {
+	cfg := &Config{Host: "  0.0.0.0  "}
+	require.NoError(t, cfg.Validate())
+}
+
+func TestValidate_RejectsInvalidHostValues(t *testing.T) {
+	for _, host := range []string{"   ", "bad_host!", "-bad.example", "bad..example", "http://localhost"} {
+		t.Run(host, func(t *testing.T) {
+			cfg := &Config{Host: host}
+			require.Error(t, cfg.Validate())
+		})
+	}
+}
+
+func TestValidate_RejectsIPv6HostValue(t *testing.T) {
+	cfg := &Config{Host: "::1"}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "IPv6")
+}
+
+func TestGetPostgresHost_DefaultsLocalOnly(t *testing.T) {
+	cfg := &Config{Host: "0.0.0.0"}
+	assert.Equal(t, "127.0.0.1", cfg.GetPostgresHost())
+}
+
+func TestGetPostgresHost_UsesServiceHostWhenExposed(t *testing.T) {
+	cfg := &Config{Host: "  devbox.local  ", ExposePostgres: true}
+	assert.Equal(t, "devbox.local", cfg.GetPostgresHost())
+}
+
 func TestResolveAdditionalBindMounts_UsesConfigDirectory(t *testing.T) {
 	configDir := t.TempDir()
 	mountDir := filepath.Join(configDir, "contracts")
@@ -319,6 +384,7 @@ func TestGetters_NilConfig(t *testing.T) {
 	assert.Equal(t, DefaultBuilderScaffoldURL, cfg.GetBuilderScaffoldURL())
 	assert.Equal(t, RecommendedWorldContractsRef, cfg.GetWorldContractsRef())
 	assert.Equal(t, RecommendedBuilderScaffoldRef, cfg.GetBuilderScaffoldRef())
+	assert.Equal(t, "127.0.0.1", cfg.GetHost())
 }
 
 func TestFindDefaultConfigPath_FindsInCurrentDirectory(t *testing.T) {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -39,6 +39,15 @@ git-autocrlf: false
 # If Podman networking fails on WSL, try setting this to "docker".
 container-engine: auto-detect
 
+# Bind address for RPC, GraphQL, and frontend port mappings (default: 127.0.0.1).
+# Set to "0.0.0.0" to expose these services on all network interfaces.
+# WARNING: Remote service exposure increases your local network attack surface.
+host: "127.0.0.1"
+
+# Keep PostgreSQL bound to localhost by default. Set to true only if you
+# intentionally need remote database access; this exposes port 5432 on the host above.
+expose-postgres: false
+
 # Additional host directories to bind-mount into the container environment.
 # additional-bind-mounts:
 #   - hostPath: ./my-extension

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -53,6 +53,7 @@ type ContainerConfig struct {
 	OpenStdin   bool
 	Healthcheck *HealthcheckDef
 	UsernsMode  string // e.g. "keep-id" for Podman
+	Host        string // bind address for port mappings (default: 127.0.0.1)
 }
 
 // ── Interface ──────────────────────────────────────────────────────
@@ -630,7 +631,7 @@ func (c *Client) ensureContainerImage(ctx context.Context, image string) error {
 
 func (c *Client) buildCreateContainerArgs(cfg ContainerConfig) []string {
 	args := []string{"create", "--name", cfg.Name}
-	args = append(args, c.preparePortConfig(cfg.Ports)...)
+	args = append(args, c.preparePortConfig(cfg.Host, cfg.Ports)...)
 	args = append(args, c.prepareMountConfig(cfg.Mounts)...)
 	args = append(args, c.prepareHealthConfig(cfg.Healthcheck)...)
 	args = append(args, c.prepareNetworkConfig(cfg.NetworkName, cfg.Aliases)...)
@@ -683,7 +684,7 @@ func (c *Client) storeHealthTest(cfg ContainerConfig) {
 	c.healthTests[cfg.Name] = cfg.Healthcheck.Test
 }
 
-func (c *Client) preparePortConfig(ports map[int]int) []string {
+func (c *Client) preparePortConfig(host string, ports map[int]int) []string {
 	if len(ports) == 0 {
 		return nil
 	}
@@ -694,7 +695,7 @@ func (c *Client) preparePortConfig(ports map[int]int) []string {
 	sort.Ints(hostPorts)
 	args := make([]string, 0, len(hostPorts)*2)
 	for _, hostPort := range hostPorts {
-		args = append(args, "-p", fmt.Sprintf("127.0.0.1:%d:%d/tcp", hostPort, ports[hostPort]))
+		args = append(args, "-p", fmt.Sprintf("%s:%d:%d/tcp", host, hostPort, ports[hostPort]))
 	}
 	return args
 }

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -51,7 +51,7 @@ func TestNetworkNameForWorkspace_UniquePerPath(t *testing.T) {
 }
 
 func TestSuiDevConfig_Ports(t *testing.T) {
-	cfg := SuiDevConfig("/workspace", "efctl-test", "docker", false, "sui", "pass", "db", nil)
+	cfg := SuiDevConfig("/workspace", "efctl-test", "docker", false, "sui", "pass", "db", nil, "127.0.0.1")
 	if _, ok := cfg.Ports[9000]; !ok {
 		t.Error("Expected port 9000 in SuiDevConfig")
 	}
@@ -59,7 +59,7 @@ func TestSuiDevConfig_Ports(t *testing.T) {
 		t.Error("Port 9125 should not be present without graphql")
 	}
 
-	cfgGql := SuiDevConfig("/workspace", "efctl-test", "docker", true, "sui", "pass", "db", nil)
+	cfgGql := SuiDevConfig("/workspace", "efctl-test", "docker", true, "sui", "pass", "db", nil, "127.0.0.1")
 	if _, ok := cfgGql.Ports[9125]; !ok {
 		t.Error("Expected port 9125 with graphql enabled")
 	}
@@ -71,12 +71,12 @@ func TestSuiDevConfig_Ports(t *testing.T) {
 func TestSuiDevConfig_PodmanUserns(t *testing.T) {
 	// The sui-dev container must use keep-id to avoid host permission
 	// issues with bind mounts in Podman rootless mode.
-	cfg := SuiDevConfig("/workspace", "efctl-test", "podman", false, "sui", "pass", "db", nil)
+	cfg := SuiDevConfig("/workspace", "efctl-test", "podman", false, "sui", "pass", "db", nil, "127.0.0.1")
 	if cfg.UsernsMode != "keep-id" {
 		t.Errorf("Expected UsernsMode 'keep-id' for Podman sui-dev, got %q", cfg.UsernsMode)
 	}
 
-	cfgDocker := SuiDevConfig("/workspace", "efctl-test", "docker", false, "sui", "pass", "db", nil)
+	cfgDocker := SuiDevConfig("/workspace", "efctl-test", "docker", false, "sui", "pass", "db", nil, "127.0.0.1")
 	if cfgDocker.UsernsMode != "" {
 		t.Errorf("Expected empty UsernsMode for Docker, got %q", cfgDocker.UsernsMode)
 	}
@@ -86,7 +86,7 @@ func TestSuiDevConfig_AdditionalBindMounts(t *testing.T) {
 	cfg := SuiDevConfig("/workspace", "efctl-test", "docker", false, "sui", "pass", "db", []AdditionalBindMount{{
 		Source:     "/tmp/contracts",
 		Identifier: "contracts_mount",
-	}})
+	}}, "127.0.0.1")
 
 	require.Len(t, cfg.Mounts, 4)
 	assert.Equal(t, "/tmp/contracts", cfg.Mounts[3].Source)
@@ -95,7 +95,7 @@ func TestSuiDevConfig_AdditionalBindMounts(t *testing.T) {
 }
 
 func TestPostgresConfig_Healthcheck(t *testing.T) {
-	cfg := PostgresConfig("efctl-test", "sui", "pass", "db")
+	cfg := PostgresConfig("efctl-test", "sui", "pass", "db", "127.0.0.1")
 	if cfg.Healthcheck == nil {
 		t.Fatal("Expected healthcheck for postgres")
 	}
@@ -105,15 +105,70 @@ func TestPostgresConfig_Healthcheck(t *testing.T) {
 	if cfg.Name != ContainerPostgres {
 		t.Errorf("Expected container name %q, got %q", ContainerPostgres, cfg.Name)
 	}
+	assert.Equal(t, "127.0.0.1", cfg.Host)
+}
+
+func TestServiceConfigs_SetHost(t *testing.T) {
+	suiCfg := SuiDevConfig("/workspace", "efctl-test", "docker", true, "sui", "pass", "db", nil, "0.0.0.0")
+	assert.Equal(t, "0.0.0.0", suiCfg.Host)
+	assert.Equal(t, map[int]int{9000: 9000, 9123: 9123, 9125: 9125}, suiCfg.Ports)
+
+	frontendCfg := FrontendConfig("/workspace", "efctl-test", "docker", "0.0.0.0")
+	assert.Equal(t, "0.0.0.0", frontendCfg.Host)
+	assert.Equal(t, map[int]int{5173: 5173}, frontendCfg.Ports)
+}
+
+func TestPostgresConfig_UsesProvidedHost(t *testing.T) {
+	cfg := PostgresConfig("efctl-test", "sui", "pass", "db", "0.0.0.0")
+	assert.Equal(t, "0.0.0.0", cfg.Host)
+	assert.Equal(t, map[int]int{5432: 5432}, cfg.Ports)
 }
 
 func TestFrontendConfig_WorkingDir(t *testing.T) {
-	cfg := FrontendConfig("/workspace", "efctl-test", "docker")
+	cfg := FrontendConfig("/workspace", "efctl-test", "docker", "127.0.0.1")
 	if cfg.WorkingDir != "/workspace/builder-scaffold/dapps" {
 		t.Errorf("Expected working dir /workspace/builder-scaffold/dapps, got %q", cfg.WorkingDir)
 	}
 	if cfg.Name != ContainerFrontend {
 		t.Errorf("Expected container name %q, got %q", ContainerFrontend, cfg.Name)
+	}
+}
+
+func TestPreparePortConfig_DefaultHost(t *testing.T) {
+	c := &Client{Engine: "docker"}
+	ports := map[int]int{9000: 9000, 5432: 5432}
+	args := c.preparePortConfig("127.0.0.1", ports)
+
+	// Should have 4 elements: -p 127.0.0.1:5432:5432/tcp -p 127.0.0.1:9000:9000/tcp
+	if len(args) != 4 {
+		t.Fatalf("expected 4 port args, got %d: %v", len(args), args)
+	}
+	if args[0] != "-p" || args[1] != "127.0.0.1:5432:5432/tcp" {
+		t.Fatalf("expected first pair to be -p 127.0.0.1:5432:5432/tcp, got %v", args[:2])
+	}
+	if args[2] != "-p" || args[3] != "127.0.0.1:9000:9000/tcp" {
+		t.Fatalf("expected second pair to be -p 127.0.0.1:9000:9000/tcp, got %v", args[2:])
+	}
+}
+
+func TestPreparePortConfig_CustomHost(t *testing.T) {
+	c := &Client{Engine: "docker"}
+	ports := map[int]int{8080: 3000}
+	args := c.preparePortConfig("0.0.0.0", ports)
+
+	if len(args) != 2 {
+		t.Fatalf("expected 2 port args, got %d", len(args))
+	}
+	if args[0] != "-p" || args[1] != "0.0.0.0:8080:3000/tcp" {
+		t.Fatalf("expected -p 0.0.0.0:8080:3000/tcp, got %v", args)
+	}
+}
+
+func TestPreparePortConfig_EmptyPorts(t *testing.T) {
+	c := &Client{Engine: "docker"}
+	args := c.preparePortConfig("127.0.0.1", nil)
+	if args != nil {
+		t.Fatalf("expected nil for empty ports, got %v", args)
 	}
 }
 

--- a/pkg/container/services.go
+++ b/pkg/container/services.go
@@ -14,7 +14,7 @@ type AdditionalBindMount struct {
 }
 
 // SuiDevConfig returns the ContainerConfig for the main Sui development node.
-func SuiDevConfig(workspace, networkName, engine string, withGraphql bool, pgUser, pgPass, pgDB string, additionalMounts []AdditionalBindMount) ContainerConfig {
+func SuiDevConfig(workspace, networkName, engine string, withGraphql bool, pgUser, pgPass, pgDB string, additionalMounts []AdditionalBindMount, host string) ContainerConfig {
 	builderScaffold := filepath.Join(workspace, "builder-scaffold")
 	worldContracts := filepath.Join(workspace, "world-contracts")
 
@@ -54,6 +54,7 @@ func SuiDevConfig(workspace, networkName, engine string, withGraphql bool, pgUse
 		Tty:         true,
 		OpenStdin:   true,
 		UsernsMode:  usernsMode,
+		Host:        host,
 	}
 }
 
@@ -76,7 +77,7 @@ func additionalBindMountDefs(additionalMounts []AdditionalBindMount) []MountDef 
 }
 
 // PostgresConfig returns the ContainerConfig for the PostgreSQL indexer database.
-func PostgresConfig(networkName, user, password, dbName string) ContainerConfig {
+func PostgresConfig(networkName, user, password, dbName, host string) ContainerConfig {
 	return ContainerConfig{
 		Name:        ContainerPostgres,
 		Image:       ImagePostgres,
@@ -92,10 +93,11 @@ func PostgresConfig(networkName, user, password, dbName string) ContainerConfig 
 			Retries:     30,
 			StartPeriod: 10 * time.Second,
 		},
+		Host: host,
 	}
 }
 
-func FrontendConfig(workspace, networkName, engine string) ContainerConfig {
+func FrontendConfig(workspace, networkName, engine, host string) ContainerConfig {
 	usernsMode := ""
 	if engine == "podman" {
 		usernsMode = "keep-id"
@@ -114,5 +116,6 @@ func FrontendConfig(workspace, networkName, engine string) ContainerConfig {
 		WorkingDir:  "/workspace/builder-scaffold/dapps",
 		Cmd:         []string{"sh", "-c", "set -e\nnpx pnpm install\nexec npx pnpm dev --host 0.0.0.0"},
 		UsernsMode:  usernsMode,
+		Host:        host,
 	}
 }

--- a/pkg/setup/host_config_test.go
+++ b/pkg/setup/host_config_test.go
@@ -1,0 +1,49 @@
+package setup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"efctl/pkg/config"
+	"efctl/pkg/container"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartPostgresKeepsLocalHostByDefault(t *testing.T) {
+	oldLoaded := config.Loaded
+	config.Loaded = &config.Config{Host: "0.0.0.0"}
+	defer func() { config.Loaded = oldLoaded }()
+
+	m := &mockContainerClient{}
+	m.On("NetworkName").Return("efctl-test")
+	m.On("CreateVolume", mock.Anything, container.VolumePgData).Return(nil)
+	m.On("CreateContainer", mock.Anything, mock.MatchedBy(func(cfg container.ContainerConfig) bool {
+		return cfg.Name == container.ContainerPostgres && cfg.Host == "127.0.0.1"
+	})).Return(nil)
+	m.On("StartContainer", mock.Anything, container.ContainerPostgres).Return(nil)
+	m.On("WaitHealthy", mock.Anything, container.ContainerPostgres, 60*time.Second).Return(nil)
+
+	require.NoError(t, startPostgres(m, context.Background(), "sui", "pass", "db"))
+	m.AssertExpectations(t)
+}
+
+func TestStartPostgresUsesServiceHostWhenExposed(t *testing.T) {
+	oldLoaded := config.Loaded
+	config.Loaded = &config.Config{Host: "0.0.0.0", ExposePostgres: true}
+	defer func() { config.Loaded = oldLoaded }()
+
+	m := &mockContainerClient{}
+	m.On("NetworkName").Return("efctl-test")
+	m.On("CreateVolume", mock.Anything, container.VolumePgData).Return(nil)
+	m.On("CreateContainer", mock.Anything, mock.MatchedBy(func(cfg container.ContainerConfig) bool {
+		return cfg.Name == container.ContainerPostgres && cfg.Host == "0.0.0.0"
+	})).Return(nil)
+	m.On("StartContainer", mock.Anything, container.ContainerPostgres).Return(nil)
+	m.On("WaitHealthy", mock.Anything, container.ContainerPostgres, 60*time.Second).Return(nil)
+
+	require.NoError(t, startPostgres(m, context.Background(), "sui", "pass", "db"))
+	m.AssertExpectations(t)
+}

--- a/pkg/setup/start.go
+++ b/pkg/setup/start.go
@@ -15,7 +15,15 @@ import (
 	"efctl/pkg/ui"
 )
 
-const defaultStartupTimeout = 10 * time.Minute
+const (
+	defaultStartupTimeout      = 10 * time.Minute
+	suiLivenessGracePeriod     = 1 * time.Second
+	suiLivenessPollInterval    = 250 * time.Millisecond
+	suiLivenessPollingTimeout  = 10 * time.Second
+	suiLivenessDiagnosticLines = 30
+)
+
+var waitForSuiLivenessFunc = waitForSuiLiveness
 
 // startupTimeoutFromEnv returns the startup timeout, defaulting to 10 minutes.
 // Override with EFCTL_STARTUP_TIMEOUT_SECONDS for CI or slow environments.
@@ -105,7 +113,7 @@ func startPostgres(c container.ContainerClient, ctx context.Context, user, pass,
 		return fmt.Errorf("failed to create pgdata volume: %w", err)
 	}
 
-	pgCfg := container.PostgresConfig(networkName, user, pass, db)
+	pgCfg := container.PostgresConfig(networkName, user, pass, db, config.Loaded.GetPostgresHost())
 	if err := c.CreateContainer(ctx, pgCfg); err != nil {
 		return fmt.Errorf("failed to create postgres container: %w", err)
 	}
@@ -125,7 +133,7 @@ func startSuiDev(c container.ContainerClient, ctx context.Context, workspace, do
 		return mountErr
 	}
 
-	suiCfg := container.SuiDevConfig(workspace, networkName, c.GetEngine(), withGraphql, pgUser, pgPass, pgDB, additionalMounts)
+	suiCfg := container.SuiDevConfig(workspace, networkName, c.GetEngine(), withGraphql, pgUser, pgPass, pgDB, additionalMounts, config.Loaded.GetHost())
 	if err := c.CreateContainer(ctx, suiCfg); err != nil {
 		return fmt.Errorf("failed to create sui-playground container: %w", err)
 	}
@@ -139,14 +147,8 @@ func startSuiDev(c container.ContainerClient, ctx context.Context, workspace, do
 		ui.Warn.Println(fmt.Sprintf("Script normalization failed (continuing): %v", err))
 	}
 
-	// Give the container a moment to start, then verify it is still running
-	// before entering the (potentially long) log-wait loop.
-	time.Sleep(10 * time.Second)
-	if !c.ContainerRunning(container.ContainerSuiPlayground) {
-		exitCode, _ := c.ContainerExitCode(container.ContainerSuiPlayground)
-		lastLogs := c.ContainerLogs(container.ContainerSuiPlayground, 30)
-		return fmt.Errorf("%s exited immediately after launch (exit code %d).\n\nLast 30 lines of container logs:\n%s",
-			container.ContainerSuiPlayground, exitCode, lastLogs)
+	if err := waitForSuiLivenessFunc(c, container.ContainerSuiPlayground, suiLivenessGracePeriod, suiLivenessPollInterval, suiLivenessPollingTimeout); err != nil {
+		return err
 	}
 
 	startupTimeout := startupTimeoutFromEnv()
@@ -184,6 +186,43 @@ func startSuiDev(c container.ContainerClient, ctx context.Context, workspace, do
 		}
 	}
 	return nil
+}
+
+func waitForSuiLiveness(c container.ContainerClient, containerName string, gracePeriod, pollInterval, timeout time.Duration) error {
+	if gracePeriod > 0 {
+		time.Sleep(gracePeriod)
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		if c.ContainerRunning(containerName) {
+			return nil
+		}
+
+		exitCode, exitErr := c.ContainerExitCode(containerName)
+		if exitErr == nil && exitCode != 0 {
+			lastLogs := c.ContainerLogs(containerName, suiLivenessDiagnosticLines)
+			return fmt.Errorf("%s exited before becoming live (exit code %d).\n\nLast %d lines of container logs:\n%s",
+				containerName, exitCode, suiLivenessDiagnosticLines, lastLogs)
+		}
+
+		if !time.Now().Before(deadline) {
+			lastLogs := c.ContainerLogs(containerName, suiLivenessDiagnosticLines)
+			return fmt.Errorf("%s did not become live within %s (ExitCode: %d, ExitErr: %v).\n\nLast %d lines of container logs:\n%s",
+				containerName, timeout, exitCode, exitErr, suiLivenessDiagnosticLines, lastLogs)
+		}
+
+		sleepFor := pollInterval
+		if sleepFor <= 0 {
+			sleepFor = time.Millisecond
+		}
+		if remaining := time.Until(deadline); remaining < sleepFor {
+			sleepFor = remaining
+		}
+		if sleepFor > 0 {
+			time.Sleep(sleepFor)
+		}
+	}
 }
 
 func resolveAdditionalContainerMounts(workspace string) ([]container.AdditionalBindMount, error) {
@@ -239,7 +278,7 @@ func startFrontend(c container.ContainerClient, ctx context.Context, workspace s
 		return fmt.Errorf("failed to create frontend modules volume: %w", err)
 	}
 
-	feCfg := container.FrontendConfig(workspace, networkName, c.GetEngine())
+	feCfg := container.FrontendConfig(workspace, networkName, c.GetEngine(), config.Loaded.GetHost())
 	if err := c.CreateContainer(ctx, feCfg); err != nil {
 		return fmt.Errorf("failed to create frontend container: %w", err)
 	}

--- a/pkg/setup/start_liveness_test.go
+++ b/pkg/setup/start_liveness_test.go
@@ -1,0 +1,102 @@
+package setup
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"efctl/pkg/container"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForSuiLivenessSucceedsWhenContainerRunning(t *testing.T) {
+	c := new(mockContainerClient)
+	c.On("ContainerRunning", container.ContainerSuiPlayground).Return(true).Once()
+
+	start := time.Now()
+	err := waitForSuiLiveness(c, container.ContainerSuiPlayground, 0, time.Hour, time.Hour)
+
+	require.NoError(t, err)
+	assert.Less(t, time.Since(start), 100*time.Millisecond)
+	c.AssertExpectations(t)
+}
+
+func TestWaitForSuiLivenessFailsEarlyWithExitDiagnostics(t *testing.T) {
+	c := new(mockContainerClient)
+	c.On("ContainerRunning", container.ContainerSuiPlayground).Return(false).Once()
+	c.On("ContainerExitCode", container.ContainerSuiPlayground).Return(42, nil).Once()
+	c.On("ContainerLogs", container.ContainerSuiPlayground, suiLivenessDiagnosticLines).Return("boom").Once()
+
+	err := waitForSuiLiveness(c, container.ContainerSuiPlayground, 0, time.Millisecond, time.Second)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exit code 42")
+	assert.Contains(t, err.Error(), "boom")
+	c.AssertExpectations(t)
+}
+
+func TestWaitForSuiLivenessTimeoutIncludesDiagnostics(t *testing.T) {
+	c := new(mockContainerClient)
+	c.On("ContainerRunning", container.ContainerSuiPlayground).Return(false)
+	c.On("ContainerExitCode", container.ContainerSuiPlayground).Return(-1, errors.New("not stopped"))
+	c.On("ContainerLogs", container.ContainerSuiPlayground, suiLivenessDiagnosticLines).Return("still starting").Once()
+
+	err := waitForSuiLiveness(c, container.ContainerSuiPlayground, 0, time.Millisecond, 2*time.Millisecond)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not become live")
+	assert.Contains(t, err.Error(), "ExitCode: -1")
+	assert.Contains(t, err.Error(), "not stopped")
+	assert.Contains(t, err.Error(), "still starting")
+	c.AssertExpectations(t)
+}
+
+func TestStartSuiDevWaitsForReadyLogAfterLiveness(t *testing.T) {
+	oldWaitForSuiLiveness := waitForSuiLivenessFunc
+	waitForSuiLivenessFunc = func(c container.ContainerClient, containerName string, gracePeriod, pollInterval, timeout time.Duration) error {
+		assert.Equal(t, container.ContainerSuiPlayground, containerName)
+		return nil
+	}
+	t.Cleanup(func() { waitForSuiLivenessFunc = oldWaitForSuiLiveness })
+
+	c := new(mockContainerClient)
+	c.On("NetworkName").Return("test-net")
+	c.On("GetEngine").Return("docker")
+	c.On("CreateContainer", mock.Anything, mock.AnythingOfType("container.ContainerConfig")).Return(nil).Once()
+	c.On("StartContainer", mock.Anything, container.ContainerSuiPlayground).Return(nil).Once()
+	c.On("Exec", mock.Anything, container.ContainerSuiPlayground, mock.AnythingOfType("[]string")).Return(nil).Maybe()
+	c.On("WaitForLogs", mock.Anything, container.ContainerSuiPlayground, container.ContainerLogReadyCtx).Return(nil).Once()
+	c.On("ExecCapture", mock.Anything, container.ContainerSuiPlayground, []string{"cat", "/workspace/.sui/.env.sui"}).Return("KEY=value\n", nil).Once()
+
+	err := startSuiDev(c, context.Background(), t.TempDir(), t.TempDir(), false, "sui", "pass", "db")
+
+	require.NoError(t, err)
+	c.AssertExpectations(t)
+}
+
+func TestStartSuiDevPropagatesLivenessFailureBeforeReadyLog(t *testing.T) {
+	oldWaitForSuiLiveness := waitForSuiLivenessFunc
+	waitForSuiLivenessFunc = func(c container.ContainerClient, containerName string, gracePeriod, pollInterval, timeout time.Duration) error {
+		return errors.New("liveness failed")
+	}
+	t.Cleanup(func() { waitForSuiLivenessFunc = oldWaitForSuiLiveness })
+
+	c := new(mockContainerClient)
+	c.On("NetworkName").Return("test-net")
+	c.On("GetEngine").Return("docker")
+	c.On("CreateContainer", mock.Anything, mock.AnythingOfType("container.ContainerConfig")).Return(nil).Once()
+	c.On("StartContainer", mock.Anything, container.ContainerSuiPlayground).Return(nil).Once()
+	c.On("Exec", mock.Anything, container.ContainerSuiPlayground, mock.AnythingOfType("[]string")).Return(nil).Maybe()
+
+	err := startSuiDev(c, context.Background(), t.TempDir(), t.TempDir(), false, "sui", "pass", "db")
+
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "liveness failed"))
+	c.AssertNotCalled(t, "WaitForLogs", mock.Anything, container.ContainerSuiPlayground, container.ContainerLogReadyCtx)
+	c.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary
- add remote development host configuration and dashboard coverage
- replace fixed Sui startup delay with bounded liveness polling before log readiness
- archive completed OpenSpec changes and sync specs

## Verification
- pre-commit run --all-files

## Credit
Co-authored-by: setkeh <setkeh@users.noreply.github.com>