### PR TITLE
chore: mitigate Scorecard code-scanning alerts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for repository-wide review routing.
+* @Scetrov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,14 @@ on:
     tags:
       - "v*.*.*"
 
-permissions:
-  contents: write
-  id-token: write
-  attestations: write
+permissions: read-all
 
 jobs:
   build:
     name: Build Binaries
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         goos: [linux, windows, darwin]
@@ -55,6 +54,10 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout code

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,4 +16,9 @@ You can update with `efctl update` or re-install with the one-liner from the REA
 
 Please report any security vulnerabilities directly to the maintainers rather than creating a public issue.
 
-You can report vulnerabilities by creating a GitHub Security Advisory or by contacting the maintainers securely. All security vulnerabilities will be promptly addressed.
+Use GitHub's private vulnerability reporting for this repository:
+
+- [Report a vulnerability privately](https://github.com/Scetrov/efctl/security/advisories/new)
+- [Repository security overview](https://github.com/Scetrov/efctl/security)
+
+Include the affected version or commit, reproduction steps, expected impact, and any suggested remediation. Maintainers will acknowledge reports within 7 days, provide status updates as the issue is investigated, and coordinate disclosure after a fix is available.

--- a/pkg/config/config_fuzz_test.go
+++ b/pkg/config/config_fuzz_test.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func FuzzConfigValidate(f *testing.F) {
+	seeds := []string{
+		"{}",
+		"world-contracts-url: https://github.com/evefrontier/world-contracts.git\n",
+		"world-contracts-url: git://example.com/repo.git\n",
+		"world-contracts-ref: main\nbuilder-scaffold-ref: v1.0.0\n",
+		"additional-bind-mounts:\n  - hostPath: ./data\n    identifier: data\n",
+		"host: localhost\nexpose-postgres: true\n",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		var cfg Config
+		if err := yaml.Unmarshal([]byte(input), &cfg); err != nil {
+			return
+		}
+		_ = cfg.Validate()
+	})
+}


### PR DESCRIPTION
## Summary
- restrict release workflow top-level `GITHUB_TOKEN` permissions to read-only and scope write/id-token/attestation permissions to the release job
- add a Go fuzz target for config YAML parsing and validation so Scorecard can detect project fuzzing coverage
- expand `SECURITY.md` with private advisory/reporting links and response expectations
- add repository CODEOWNERS to route review ownership for future branch protection / review rules

## Validation
- `go test ./...`
- `pre-commit run --all-files`

## Notes
Some Scorecard alerts require repository settings or maintainer enrollment outside a code PR:
- Branch-Protection: enable required PR reviews, last-push approval, up-to-date branches, and apply rules to administrators for `main`.
- Code-Review: after branch protection is enabled, require CODEOWNER/maintainer review before merge.
- CII-Best-Practices: register/enroll the project at https://www.bestpractices.dev/.
