### PR TITLE
chore(ci): scope scorecard permissions to job

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write # Required to upload SARIF to code scanning.
-  id-token: write # Required when publish_results is enabled.
 
 jobs:
   analysis:


### PR DESCRIPTION
## Description

Remove redundant workflow-level `security-events` and `id-token` permissions from the Scorecard workflow. These permissions remain scoped to the `analysis` job that requires them, preserving least privilege without changing workflow behavior.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] CI/security hardening

## How Has This Been Tested?

- [x] `pre-commit run --all-files`
- [x] `go test ./...` (via pre-commit)
- [ ] Local environment deployment (`efctl env up`) — not applicable

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] No documentation changes are required
- [x] No dependent downstream changes are required
