### PR TITLE
Adding Race Condition Patch Function

### DIFF
--- a/pkg/setup/docker_patch.go
+++ b/pkg/setup/docker_patch.go
@@ -270,7 +270,7 @@ sleep 2
 echo "[sui-dev] Waiting for faucet on port 9123..."
 FAUCET_READY=0
 for i in $(seq 1 60); do
-  curl -s -o /dev/null http://127.0.0.1:9123 2>/dev/null && { FAUCET_READY=1; break; }
+  curl --max-time 10 -s -o /dev/null http://127.0.0.1:9123 2>/dev/null && { FAUCET_READY=1; break; }
   sleep 1
 done
 if [ "$FAUCET_READY" -ne 1 ]; then

--- a/pkg/setup/docker_patch.go
+++ b/pkg/setup/docker_patch.go
@@ -120,6 +120,8 @@ func patchEntrypoint(dockerDir string) {
 	content = patchEntrypointPostgresWait(content)
 	content = patchEntrypointSuiStart(content)
 	content = patchEntrypointLoopTimings(content)
+	content = patchEntrypointFaucetWait(content)
+	content = patchEntrypointFaucetResilience(content)
 
 	// Post-patch validation: ensure the bind-mount .env.sui path was fully
 	// eliminated. If any patch above silently failed (e.g. upstream changed
@@ -244,4 +246,60 @@ echo "[sui-dev] Node ready."`
 		content = strings.ReplaceAll(content, "sleep 2\necho \"[sui-dev] RPC ready.\"", rpcWaitScript)
 	}
 	return content
+}
+
+// patchEntrypointFaucetWait fixes a race condition in the upstream entrypoint:
+// `sui start --with-faucet` runs the RPC (port 9000) and the faucet HTTP
+// server (port 9123) as two independently-initializing components of the
+// same process, but the script only polls port 9000 and then assumes the
+// faucet is ready after a flat 5-second sleep. On a loaded host that's not
+// always enough, and the very next step (funding ADMIN/PLAYER_A/PLAYER_B)
+// gets connection-refused and aborts the whole container. This replaces the
+// fixed sleep with a real poll on port 9123 before proceeding.
+func patchEntrypointFaucetWait(content string) string {
+	if strings.Contains(content, "Waiting for faucet on port 9123") {
+		return content
+	}
+
+	old := `echo "[sui-dev] RPC responding, waiting for full initialization..."
+sleep 5
+echo "[sui-dev] Node ready."`
+
+	faucetWaitScript := `echo "[sui-dev] RPC responding, waiting for full initialization..."
+sleep 2
+echo "[sui-dev] Waiting for faucet on port 9123..."
+FAUCET_READY=0
+for i in $(seq 1 60); do
+  curl -s -o /dev/null http://127.0.0.1:9123 2>/dev/null && { FAUCET_READY=1; break; }
+  sleep 1
+done
+if [ "$FAUCET_READY" -ne 1 ]; then
+  echo "[sui-dev] WARNING: faucet did not respond within 60s; funding may fail" >&2
+fi
+echo "[sui-dev] Node ready."`
+
+	return strings.ReplaceAll(content, old, faucetWaitScript)
+}
+
+// patchEntrypointFaucetResilience stops a transient faucet-funding failure
+// from killing the entire dev environment. The chain (RPC, indexer, GraphQL)
+// is already fully up by this point — failing to fund one account is a
+// narrow, recoverable problem (the operator can retry with
+// `efctl env faucet --address <addr>`), not a reason to tear down everything
+// and force a full `env down && env up` cycle.
+func patchEntrypointFaucetResilience(content string) string {
+	if strings.Contains(content, "will not be funded automatically") {
+		return content
+	}
+
+	old := `    [ "$attempt" -eq 3 ] && {
+      echo "[sui-dev] Faucet failed for $alias" >&2
+      exit 1
+    }`
+
+	resilientScript := `    [ "$attempt" -eq 3 ] && {
+      echo "[sui-dev] WARNING: faucet failed for $alias after 3 attempts; it will not be funded automatically. Retry later with: efctl env faucet --address <address>" >&2
+    }`
+
+	return strings.ReplaceAll(content, old, resilientScript)
 }

--- a/pkg/setup/docker_patch_test.go
+++ b/pkg/setup/docker_patch_test.go
@@ -183,6 +183,135 @@ sui start --with-faucet --force-regenesis &
 	assert.Contains(t, string(body), `/workspace/.sui/.env.sui`)
 }
 
+// ── patchEntrypointFaucetWait ────────────────────────────────────────
+
+func TestPatchEntrypointFaucetWait_ReplacesFixedSleep(t *testing.T) {
+	content := `echo "[sui-dev] RPC responding, waiting for full initialization..."
+sleep 5
+echo "[sui-dev] Node ready."`
+
+	result := patchEntrypointFaucetWait(content)
+	assert.Contains(t, result, "Waiting for faucet on port 9123")
+	assert.Contains(t, result, "curl -s -o /dev/null http://127.0.0.1:9123")
+	assert.Contains(t, result, `echo "[sui-dev] Node ready."`)
+	// The unconditional fixed sleep must be gone in favour of a bounded poll.
+	assert.NotContains(t, result, "sleep 5\necho \"[sui-dev] Node ready.\"")
+}
+
+func TestPatchEntrypointFaucetWait_Idempotent(t *testing.T) {
+	content := `echo "[sui-dev] RPC responding, waiting for full initialization..."
+sleep 5
+echo "[sui-dev] Node ready."`
+
+	first := patchEntrypointFaucetWait(content)
+	second := patchEntrypointFaucetWait(first)
+	assert.Equal(t, first, second)
+}
+
+func TestPatchEntrypointFaucetWait_NoOpWhenMarkerAbsent(t *testing.T) {
+	// If upstream has already changed this section beyond recognition, the
+	// patch must not corrupt the file — it should leave it untouched.
+	content := `echo "[sui-dev] Something else entirely"`
+	result := patchEntrypointFaucetWait(content)
+	assert.Equal(t, content, result)
+}
+
+// ── patchEntrypointFaucetResilience ──────────────────────────────────
+
+func TestPatchEntrypointFaucetResilience_ReplacesExitWithWarning(t *testing.T) {
+	content := `for alias in ADMIN PLAYER_A PLAYER_B; do
+  sui client switch --address "$alias"
+  for attempt in 1 2 3; do
+    sui client faucet 2>&1 && break
+    [ "$attempt" -eq 3 ] && {
+      echo "[sui-dev] Faucet failed for $alias" >&2
+      exit 1
+    }
+    sleep 2
+  done
+done`
+
+	result := patchEntrypointFaucetResilience(content)
+	assert.Contains(t, result, "will not be funded automatically")
+	assert.Contains(t, result, "efctl env faucet --address")
+	// A single funding failure must no longer terminate the whole script.
+	assert.NotContains(t, result, "exit 1")
+}
+
+func TestPatchEntrypointFaucetResilience_Idempotent(t *testing.T) {
+	content := `    [ "$attempt" -eq 3 ] && {
+      echo "[sui-dev] Faucet failed for $alias" >&2
+      exit 1
+    }`
+
+	first := patchEntrypointFaucetResilience(content)
+	second := patchEntrypointFaucetResilience(first)
+	assert.Equal(t, first, second)
+}
+
+func TestPatchEntrypointFaucetResilience_NoOpWhenMarkerAbsent(t *testing.T) {
+	content := `echo "[sui-dev] Something else entirely"`
+	result := patchEntrypointFaucetResilience(content)
+	assert.Equal(t, content, result)
+}
+
+// ── patchEntrypoint end-to-end: faucet patches applied together ─────
+
+func TestPatchEntrypoint_FaucetPatchesAppliedTogether(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptsDir := filepath.Join(tmpDir, "scripts")
+	os.MkdirAll(scriptsDir, 0755)
+	entrypointPath := filepath.Join(scriptsDir, "entrypoint.sh")
+
+	// Mirrors the real upstream builder-scaffold entrypoint.sh shape for the
+	// node-start-through-funding section.
+	content := `#!/usr/bin/env bash
+set -e
+SUI_CFG="${SUI_CONFIG_DIR:-/root/.sui}"
+ENV_FILE="/workspace/builder-scaffold/docker/.env.sui"
+
+# ---------- start local node ----------
+sui start --with-faucet --force-regenesis &
+NODE_PID=$!
+
+echo "[sui-dev] Waiting for RPC on port 9000..."
+for i in $(seq 1 30); do
+  curl -s -o /dev/null http://127.0.0.1:9000 2>/dev/null && break
+  if [ "$i" -eq 30 ]; then
+    echo "[sui-dev] ERROR: RPC did not become ready" >&2
+    exit 1
+  fi
+  sleep 1
+done
+echo "[sui-dev] RPC responding, waiting for full initialization..."
+sleep 5
+echo "[sui-dev] Node ready."
+
+# ---------- fund accounts ----------
+echo "[sui-dev] Funding accounts from faucet..."
+for alias in ADMIN PLAYER_A PLAYER_B; do
+  sui client switch --address "$alias"
+  for attempt in 1 2 3; do
+    sui client faucet 2>&1 && break
+    [ "$attempt" -eq 3 ] && {
+      echo "[sui-dev] Faucet failed for $alias" >&2
+      exit 1
+    }
+    sleep 2
+  done
+done
+`
+	os.WriteFile(entrypointPath, []byte(content), 0755)
+
+	patchEntrypoint(tmpDir)
+
+	body, _ := os.ReadFile(entrypointPath)
+	bodyStr := string(body)
+	assert.Contains(t, bodyStr, "Waiting for faucet on port 9123", "faucet-wait patch should be applied")
+	assert.Contains(t, bodyStr, "will not be funded automatically", "faucet-resilience patch should be applied")
+	assert.NotContains(t, bodyStr, "exit 1\n    }", "faucet funding failure must no longer be fatal")
+}
+
 // ── patchDockerfile safety-net ──────────────────────────────────────
 
 func TestPatchDockerfile_InjectsSedSafetyNet(t *testing.T) {

--- a/pkg/setup/docker_patch_test.go
+++ b/pkg/setup/docker_patch_test.go
@@ -192,7 +192,7 @@ echo "[sui-dev] Node ready."`
 
 	result := patchEntrypointFaucetWait(content)
 	assert.Contains(t, result, "Waiting for faucet on port 9123")
-	assert.Contains(t, result, "curl -s -o /dev/null http://127.0.0.1:9123")
+	assert.Contains(t, result, "curl --max-time 10 -s -o /dev/null http://127.0.0.1:9123")
 	assert.Contains(t, result, `echo "[sui-dev] Node ready."`)
 	// The unconditional fixed sleep must be gone in favour of a bounded poll.
 	assert.NotContains(t, result, "sleep 5\necho \"[sui-dev] Node ready.\"")


### PR DESCRIPTION
# Pull Request Template

## Description

During my Last PR i encountered an issue where startup can fail when trying to fund the localnet wallets.
<img width="1111" height="1321" alt="image" src="https://github.com/user-attachments/assets/7e9dd06d-7de3-4066-b764-89fc06af1e73" />

This issue appears to be caused by an assumption made upstream in https://github.com/evefrontier/builder-scaffold/blob/main/docker/scripts/entrypoint.sh#L123-L125 where the entrypoint waits for 5 seconds before declaring that the Sui-Dev node is ready, While this works fine for manual deployment of the builder scaffold most of the time (and in a clean docker environment with only EFCTL) this wait causes the race condition in busier docker environments as the container is rarely fully ready in 5 seconds.

Specific Details in the Changes below but the Gist is I have added a real check that actually touches the endpoint to confirm its ready instead of assuming it is after 5 seconds, I have also stopped the container from failing if funding accounts fails as doing that manually out of the startup loop is reasonably simple.


Changes:

- **Fix faucet startup race in `sui-dev` entrypoint patching** (`pkg/setup/docker_patch.go`): `sui start --with-faucet` initializes the RPC (port 9000) and faucet HTTP server (port 9123) independently, but the entrypoint only polled port 9000 then assumed the faucet was ready after a flat 5-second sleep. On a loaded host this isn't always enough, and the funding step (`sui client faucet` for ADMIN/PLAYER_A/PLAYER_B) would get connection-refused and abort the whole container. Added `patchEntrypointFaucetWait`, which replaces the fixed sleep with a real poll loop on port 9123 (same pattern as the existing RPC-wait loop) before declaring the node ready.

- **Stop a single funding failure from killing the whole environment** (`pkg/setup/docker_patch.go`): even with the wait fixed, a transient faucet hiccup shouldn't be fatal — the chain, indexer, and GraphQL are already fully up by that point. Added `patchEntrypointFaucetResilience`, which changes the funding-failure branch from `exit 1` to a warning pointing at the existing `efctl env faucet --address <addr>` command for manual retry.

- **Wired both new patches into `patchEntrypoint()`**, run immediately after the existing `patchEntrypointLoopTimings` step so they operate on the post-timing-patch text.

- **Tests** (`pkg/setup/docker_patch_test.go`): 8 new tests — replacement/idempotency/no-op-when-marker-absent unit tests for each new patch function, plus an end-to-end test (`TestPatchEntrypoint_FaucetPatchesAppliedTogether`) that runs a realistic upstream-shaped `entrypoint.sh` through the full `patchEntrypoint()` pipeline and asserts both patches land correctly together.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] `go test ./...`
- [x] Local environment deployment (`efctl env up`)

```
❯ go test ./...
ok      efctl   (cached)
ok      efctl/cmd       (cached)
ok      efctl/internal/blake2b256       (cached)
?       efctl/pkg/assembly      [no test files]
ok      efctl/pkg/builder       (cached)
ok      efctl/pkg/config        (cached)
ok      efctl/pkg/container     (cached)
ok      efctl/pkg/dashboard     (cached)
ok      efctl/pkg/doctor        0.577s
ok      efctl/pkg/env   (cached)
ok      efctl/pkg/git   (cached)
ok      efctl/pkg/graphql       (cached)
?       efctl/pkg/mocks [no test files]
ok      efctl/pkg/setup (cached)
ok      efctl/pkg/status        (cached)
ok      efctl/pkg/sui   (cached)
ok      efctl/pkg/ui    (cached)
ok      efctl/pkg/validate      (cached)
?       efctl/tools/gen-docs    [no test files]
?       efctl/tools/test-exec   [no test files]
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
